### PR TITLE
ntp,systemd: switch to flatcar's NTP zone

### DIFF
--- a/net-misc/ntp/files/ntp.conf
+++ b/net-misc/ntp/files/ntp.conf
@@ -1,8 +1,8 @@
 # Common pool
-server 0.coreos.pool.ntp.org
-server 1.coreos.pool.ntp.org
-server 2.coreos.pool.ntp.org
-server 3.coreos.pool.ntp.org
+server 0.flatcar.pool.ntp.org
+server 1.flatcar.pool.ntp.org
+server 2.flatcar.pool.ntp.org
+server 3.flatcar.pool.ntp.org
 
 # Warning: Using default NTP settings will leave your NTP
 # server accessible to all hosts on the Internet.

--- a/net-misc/ntp/files/ntpdate.service
+++ b/net-misc/ntp/files/ntpdate.service
@@ -7,7 +7,7 @@ Conflicts=systemd-timesyncd.service
 
 [Service]
 Type=oneshot
-Environment="SERVER=0.coreos.pool.ntp.org 1.coreos.pool.ntp.org 2.coreos.pool.ntp.org 3.coreos.pool.ntp.org"
+Environment="SERVER=0.flatcar.pool.ntp.org 1.flatcar.pool.ntp.org 2.flatcar.pool.ntp.org 3.flatcar.pool.ntp.org"
 ExecStart=/usr/sbin/ntpdate -b -u $SERVER
 RemainAfterExit=yes
 

--- a/net-misc/ntp/files/sntp.service
+++ b/net-misc/ntp/files/sntp.service
@@ -7,7 +7,7 @@ Conflicts=systemd-timesyncd.service
 
 [Service]
 Type=oneshot
-Environment="SERVER=0.coreos.pool.ntp.org 1.coreos.pool.ntp.org 2.coreos.pool.ntp.org 3.coreos.pool.ntp.org"
+Environment="SERVER=0.flatcar.pool.ntp.org 1.flatcar.pool.ntp.org 2.flatcar.pool.ntp.org 3.flatcar.pool.ntp.org"
 ExecStart=/usr/bin/sntp -s $SERVER
 RemainAfterExit=yes
 

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -269,7 +269,7 @@ multilib_src_configure() {
 		-Ddbussessionservicedir="${EPREFIX}/usr/share/dbus-1/services"
 		-Ddbussystemservicedir="${EPREFIX}/usr/share/dbus-1/system-services"
 
-		-Dntp-servers="0.coreos.pool.ntp.org 1.coreos.pool.ntp.org 2.coreos.pool.ntp.org 3.coreos.pool.ntp.org"
+		-Dntp-servers="0.flatcar.pool.ntp.org 1.flatcar.pool.ntp.org 2.flatcar.pool.ntp.org 3.flatcar.pool.ntp.org"
 
 		-Dpamconfdir=/usr/share/pam.d
 


### PR DESCRIPTION
We set up a vendor pool zone, let's use it instead of coreos'.

Fixes flatcar-linux/Flatcar#2