### PR TITLE
Change back flatcar-metadata to coreos-metadata

### DIFF
--- a/coreos-base/coreos-metadata/coreos-metadata-9999.ebuild
+++ b/coreos-base/coreos-metadata/coreos-metadata-9999.ebuild
@@ -47,10 +47,10 @@ src_prepare() {
 src_install() {
 	cargo_src_install
 
-	mv "${D}/usr/bin/coreos-metadata" "${D}/usr/bin/flatcar-metadata"
+	mv "${D}/usr/bin/coreos-metadata" "${D}/usr/bin/coreos-metadata"
 
-	systemd_dounit "${FILESDIR}/flatcar-metadata.service"
-	systemd_dounit "${FILESDIR}/flatcar-metadata-sshkeys@.service"
+	systemd_dounit "${FILESDIR}/coreos-metadata.service"
+	systemd_dounit "${FILESDIR}/coreos-metadata-sshkeys@.service"
 }
 
 # sed -n 's/^"checksum \([^ ]*\) \([^ ]*\) .*/\1-\2/p' Cargo.lock

--- a/coreos-base/coreos-metadata/files/coreos-metadata-sshkeys@.service
+++ b/coreos-base/coreos-metadata/files/coreos-metadata-sshkeys@.service
@@ -4,7 +4,7 @@ Description=Flatcar Metadata Agent (SSH Keys)
 [Service]
 Type=oneshot
 Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
-ExecStart=/usr/bin/flatcar-metadata ${COREOS_METADATA_OPT_PROVIDER} --ssh-keys=%i
+ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --ssh-keys=%i
 
 [Install]
 DefaultInstance=core

--- a/coreos-base/coreos-metadata/files/coreos-metadata.service
+++ b/coreos-base/coreos-metadata/files/coreos-metadata.service
@@ -4,7 +4,7 @@ Description=Flatcar Metadata Agent
 [Service]
 Type=oneshot
 Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
-ExecStart=/usr/bin/flatcar-metadata ${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
+ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
 
 [Install]
 RequiredBy=metadata.target

--- a/coreos-base/oem-digitalocean/files/base/base.ign
+++ b/coreos-base/oem-digitalocean/files/base/base.ign
@@ -5,7 +5,7 @@
   "systemd": {
     "units": [
       {
-        "name": "flatcar-metadata-sshkeys@.service",
+        "name": "coreos-metadata-sshkeys@.service",
         "enabled": true
       }
     ]

--- a/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
+++ b/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
@@ -5,7 +5,7 @@
   "systemd": {
     "units": [
       {
-        "name": "flatcar-metadata-sshkeys@.service",
+        "name": "coreos-metadata-sshkeys@.service",
         "enabled": true
       }
     ]

--- a/coreos-base/oem-gce/files/base/base.ign
+++ b/coreos-base/oem-gce/files/base/base.ign
@@ -33,7 +33,7 @@
   "systemd": {
     "units": [
       {
-        "name": "flatcar-metadata-sshkeys@.service",
+        "name": "coreos-metadata-sshkeys@.service",
         "enabled": true
       },
       {

--- a/coreos-base/oem-oracle-oci/files/base/base.ign
+++ b/coreos-base/oem-oracle-oci/files/base/base.ign
@@ -25,7 +25,7 @@
   "systemd": {
     "units": [
       {
-        "name": "flatcar-metadata-sshkeys@.service",
+        "name": "coreos-metadata-sshkeys@.service",
         "enabled": true
       },
       {

--- a/coreos-base/oem-packet/files/base/base.ign
+++ b/coreos-base/oem-packet/files/base/base.ign
@@ -17,7 +17,7 @@
   "systemd": {
     "units": [
       {
-        "name": "flatcar-metadata-sshkeys@.service",
+        "name": "coreos-metadata-sshkeys@.service",
         "enabled": true
       },
       {

--- a/coreos-base/oem-packet/files/units/packet-phone-home.service
+++ b/coreos-base/oem-packet/files/units/packet-phone-home.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Report Success to Packet
 ConditionFirstBoot=true
-Requires=flatcar-metadata.service
-After=flatcar-metadata.service
+Requires=coreos-metadata.service
+After=coreos-metadata.service
 
 [Service]
 EnvironmentFile=/run/metadata/flatcar


### PR DESCRIPTION
There's no need to rename this since coreos-metadata is just the name of
the project.