### PR TITLE
app-arch/torcx: switch libcoreosdir to /usr/lib/flatcar

### DIFF
--- a/app-arch/torcx/torcx-9999.ebuild
+++ b/app-arch/torcx/torcx-9999.ebuild
@@ -34,7 +34,7 @@ src_compile() {
 src_install() {
 	local generatordir=/usr/lib/systemd/system-generators
 	local vendordir=/usr/share/torcx
-	local libcoreosdir=/usr/lib/coreos
+	local libcoreosdir=/usr/lib/flatcar
 
 	# Install generator and userland.
 	exeinto "${generatordir}"


### PR DESCRIPTION
This was breaking our symlink `/usr/lib/coreos` -> `/usr/lib/flatcar`
since it was make a copy of it before creating an actual `coreos`
directory, ending up with this structure:

```
core@machine ~ $ ls -ld /usr/lib/core*
drwxr-xr-x. 2 root root 4096 Sep 13 15:37 /usr/lib/coreos
lrwxrwxrwx. 1 root root    7 Sep 13 15:41 /usr/lib/coreos.backup.0000 -> flatcar
```

Without that symlink, applications expecting it broke, like, for
example, the `kubelet-wrapper` systemd service.