### PR TITLE
sys-kernel: set KV_OUT_DIR explicitly instead of COREOS_SOURCE_NAME.

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -8,7 +8,8 @@
 : ${COREOS_SOURCE_REVISION:=}
 
 COREOS_SOURCE_VERSION="${PV}${COREOS_SOURCE_REVISION}"
-COREOS_SOURCE_NAME="linux-${PV/_rc/-rc}-flatcar${COREOS_SOURCE_REVISION}"
+COREOS_SOURCE_NAME="linux-${PV/_rc/-rc}-coreos${COREOS_SOURCE_REVISION}"
+FLATCAR_SOURCE_NAME="linux-${PV/_rc/-rc}-flatcar${COREOS_SOURCE_REVISION}"
 
 [[ ${EAPI} != "5" ]] && die "Only EAPI=5 is supported"
 

--- a/sys-kernel/coreos-kernel/coreos-kernel-4.19.0.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.19.0.ebuild
@@ -53,7 +53,7 @@ pkg_setup() {
 src_prepare() {
 	# KV_OUT_DIR points to the minimal build tree installed by coreos-modules
 	# Pull in the config and public module signing key
-	KV_OUT_DIR="${ROOT%/}/lib/modules/${COREOS_SOURCE_NAME#linux-}/build"
+	KV_OUT_DIR="${ROOT%/}/lib/modules/${FLATCAR_SOURCE_NAME#linux-}/build"
 	cp -v "${KV_OUT_DIR}/.config" build/ || die
 	local sig_key="$(getconfig MODULE_SIG_KEY)"
 	mkdir -p "build/${sig_key%/*}" || die


### PR DESCRIPTION
We should not change `$COREOS_SOURCE_NAME` to `linux-4.19.0-flatcar`, because `$KERNEL_DIR` depends on the variable. Since $KERNEL_DIR `/usr/src/linux-4.19.0-flatcar` does not exist, kernel module builds will fail. That's because coreos-sources distributes the kernel source with the name of "-coreos". It's hard to change the name without touching a lot of places.

So let's set `$COREOS_SOURCE_NAME` back to `linux-4.19.0-coreos`, and explicitly define `$KV_OUT_DIR` that uses `$FLATCAR_SOURCE_NAME`, e.g. `/usr/src/linux-4.19.0-flatcar`. That way, we can minimize a mount of changes.