### PR TITLE
eclass: make again KERNEL_DIR have coreos kernel name

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -8,6 +8,19 @@
 : ${COREOS_SOURCE_REVISION:=}
 
 COREOS_SOURCE_VERSION="${PV}${COREOS_SOURCE_REVISION}"
+
+# $COREOS_KERNEL_SOURCE_NAME is the kernel source name to be used for
+# $KERNEL_DIR, e.g. linux-4.19.0-coreos. This comes from upstream, so
+# Flatcar should not change it.
+#
+# On the other hand, $COREOS_SOURCE_NAME is the kernel name to be used for
+# $KV_OUT_DIR in individual coreos-kernel*.ebuild files. That one needs to
+# have a flatcar-specific name. We cannot define another variable like
+# $FLATCAR_SOURCE_NAME, because it will then be rewritten by upstream changes
+# that set $COREOS_SOURCE_NAME by default. In the Gentoo world, the ebuild
+# for each new version has a totally new file name. So it's hard to replace
+# a new $COREOS_SOURCE_NAME variable for every new ebuild.
+COREOS_KERNEL_SOURCE_NAME="linux-${PV/_rc/-rc}-coreos${COREOS_SOURCE_REVISION}"
 COREOS_SOURCE_NAME="linux-${PV/_rc/-rc}-flatcar${COREOS_SOURCE_REVISION}"
 
 [[ ${EAPI} != "5" ]] && die "Only EAPI=5 is supported"
@@ -29,7 +42,9 @@ RESTRICT="binchecks strip"
 QA_MULTILIB_PATHS="usr/lib/modules/.*/build/scripts/.*"
 
 # Use source installed by coreos-sources
-KERNEL_DIR="${SYSROOT}/usr/src/${COREOS_SOURCE_NAME}"
+# KERNEL_DIR must find the kernel source tree under /usr/src/linux-*-coreos,
+# not /usr/src/linux-*-flatcar, which does not exist at all.
+KERNEL_DIR="${SYSROOT}/usr/src/${COREOS_KERNEL_SOURCE_NAME}"
 
 # Search for an appropriate config in ${FILESDIR}. The config should reflect
 # the kernel version but partial matching is allowed if the config is


### PR DESCRIPTION
Since 653e4d0852431a0daef77314a921e25562b2a53b, $KERNEL_DIR is broken again. It needs to be `-coreos`, not `-flatcar`.

To fix that, define another variable $COREOS_KERNEL_SOURCE_NAME, which
is `/usr/src/linux-*-coreos`