### PR TITLE
sys-kernel: make KV_OUT_DIR use again COREOS_SOURCE_NAME

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.14.79.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.14.79.ebuild
@@ -54,7 +54,7 @@ pkg_setup() {
 src_prepare() {
 	# KV_OUT_DIR points to the minimal build tree installed by coreos-modules
 	# Pull in the config and public module signing key
-	KV_OUT_DIR="${ROOT%/}/lib/modules/${FLATCAR_SOURCE_NAME#linux-}/build"
+	KV_OUT_DIR="${ROOT%/}/lib/modules/${COREOS_SOURCE_NAME#linux-}/build"
 	cp -v "${KV_OUT_DIR}/.config" build/ || die
 	local sig_key="$(getconfig MODULE_SIG_KEY)"
 	mkdir -p "build/${sig_key%/*}" || die


### PR DESCRIPTION
`FLATCAR_SOURCE_NAME` does not exist. Use only `COREOS_SOURCE_NAME`.