### PR TITLE
profiles: add CFLAGS to prevent the Spectre v2

### DIFF
--- a/profiles/coreos/amd64/generic/make.defaults
+++ b/profiles/coreos/amd64/generic/make.defaults
@@ -1,3 +1,3 @@
 # Enable optimizations for common x86_64 CPUs
-CFLAGS="-O2 -pipe -mtune=generic -g"
+CFLAGS="-O2 -pipe -mtune=generic -g -mindirect-branch=thunk -mindirect-branch-register"
 CXXFLAGS="${CFLAGS}"

--- a/profiles/coreos/amd64/sdk/make.defaults
+++ b/profiles/coreos/amd64/sdk/make.defaults
@@ -1,3 +1,3 @@
 # Enable optimizations for common x86_64 CPUs
-CFLAGS="-O2 -pipe -mtune=generic"
+CFLAGS="-O2 -pipe -mtune=generic -mindirect-branch=thunk -mindirect-branch-register"
 CXXFLAGS="${CFLAGS}"


### PR DESCRIPTION
To be able to prevent the Spectre v2, we should add the following CFLAGS `-mindirect-branch=thunk` and `-mindirect-branch-register` for the general profile.

This PR has to be tested together with https://github.com/flatcar-linux/portage-stable/pull/2.

See also:
https://security.googleblog.com/2018/01/more-details-about-mitigations-for-cpu_4.html
https://groups.google.com/forum/#!topic/linux.gentoo.user/6xUuPccmxtU