### PR TITLE
eclass: trim suffix REVISION from COREOS_SOURCE_VERSION

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -20,8 +20,10 @@ COREOS_SOURCE_VERSION="${PV}${COREOS_SOURCE_REVISION}"
 # that set $COREOS_SOURCE_NAME by default. In the Gentoo world, the ebuild
 # for each new version has a totally new file name. So it's hard to replace
 # a new $COREOS_SOURCE_NAME variable for every new ebuild.
+# $COREOS_SOURCE_NAME should be a name without a revision suffix (e.g. "-r1"),
+# because $KV_FULL would not include such a suffix.
 COREOS_KERNEL_SOURCE_NAME="linux-${PV/_rc/-rc}-coreos${COREOS_SOURCE_REVISION}"
-COREOS_SOURCE_NAME="linux-${PV/_rc/-rc}-flatcar${COREOS_SOURCE_REVISION}"
+COREOS_SOURCE_NAME="linux-${PV/_rc/-rc}-flatcar"
 
 [[ ${EAPI} != "5" ]] && die "Only EAPI=5 is supported"
 


### PR DESCRIPTION
In case of a suffix `$COREOS_SOURCE_REVISION` expliticly given by the user, like `-r1`, `$COREOS_SOURCE_NAME` should not include the revision suffix. That's because the individual coreos-kernel*ebuild will make use of `$COREOS_SOURCE_NAME` as a base of `$KV_OUT_DIR`.

Otherwise the build will fail because `/build/amd64-usr/lib/modules/4.14.96-flatcar-r1` does not exist. More precisely, that's because `$KV_FULL` given by the upstream eclass does not include the suffix, e.g. `/build/amd64-usr/lib/modules/4.14.96-flatcar`,