### PR TITLE
coreos-base/coreos-init: add more systemd-networkd configs

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="49cece6a0aed61dfdffaa1cb511b6d7e0b5dedad"
+	CROS_WORKON_COMMIT="47b635fed4c9c89419bc17e345f6c1ee60c56918"
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Since we added several systemd-networkd config files to [flatcar-linux/init](https://github.com/flatcar-linux/init), we need to also update coreos-init to pull the newest commit of coreos-init.

See also https://github.com/flatcar-linux/init/pull/6