### PR TITLE
coreos-base: add bpftool and cgroupid to the base packages list

### DIFF
--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -131,6 +131,8 @@ RDEPEND="${RDEPEND}
 	net-misc/socat
 	net-misc/wget
 	net-misc/whois
+	sys-apps/bpftool
+	sys-apps/cgroupid
 	sys-apps/coreutils
 	sys-apps/dbus
 	sys-apps/ethtool


### PR DESCRIPTION
To make the new tools `bpftool` and `cgroupid` included in the final image, we need to add the tools to the coreos packages list.