### PR TITLE
app-emulation/cri-o: disable go build install flag

### DIFF
--- a/app-emulation/cri-o/cri-o-1.13.5.ebuild
+++ b/app-emulation/cri-o/cri-o-1.13.5.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 EGIT_COMMIT="a9d8dde49418572b6ea843a5d3346c966e82077f"
 EGO_PN="github.com/cri-o/${PN}"
 
-inherit golang-vcs-snapshot systemd
+inherit eutils golang-vcs-snapshot systemd
 
 DESCRIPTION="OCI-based implementation of Kubernetes Container Runtime Interface"
 HOMEPAGE="https://cri-o.io/"
@@ -37,6 +37,8 @@ S="${WORKDIR}/${P}/src/${EGO_PN}"
 
 src_prepare() {
 	default
+
+	epatch "${FILESDIR}/0001-Remove-go-build-i-flag.patch"
 
 	sed -e '/^GIT_.*/d' \
 		-e '/	git diff --exit-code/d' \

--- a/app-emulation/cri-o/files/0001-Remove-go-build-i-flag.patch
+++ b/app-emulation/cri-o/files/0001-Remove-go-build-i-flag.patch
@@ -1,0 +1,60 @@
+From a42f5ccad54673066ea6b236916df166025be9e3 Mon Sep 17 00:00:00 2001
+Message-Id: <a42f5ccad54673066ea6b236916df166025be9e3.1556517764.git.dongsu@kinvolk.io>
+From: Sascha Grunert <sgrunert@suse.com>
+Date: Tue, 23 Apr 2019 09:54:33 +0200
+Subject: [PATCH] Remove go build -i flag
+
+The repository should be completely self containing so that the
+-i flag is not needed any more.
+
+Signed-off-by: Sascha Grunert <sgrunert@suse.com>
+---
+ Makefile | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 08ebd70f..034ab94f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -106,16 +106,16 @@ bin/conmon: conmon/config.h
+ 	$(MAKE) -C pause
+ 
+ test/bin2img/bin2img: .gopathok $(wildcard test/bin2img/*.go)
+-	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/bin2img
++	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/bin2img
+ 
+ test/copyimg/copyimg: .gopathok $(wildcard test/copyimg/*.go)
+-	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/copyimg
++	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/copyimg
+ 
+ test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
+-	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkseccomp
++	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkseccomp
+ 
+ bin/crio: .gopathok
+-	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crio
++	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crio
+ 
+ crio.conf: bin/crio
+ 	./bin/crio --config="" config --default > crio.conf
+@@ -124,7 +124,7 @@ release-note: ${RELEASE_TOOL}
+ 	${RELEASE_TOOL} -n $(release)
+ 
+ conmon/config.h: cmd/crio-config/config.go oci/oci.go
+-	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS)" -o bin/crio-config $(PROJECT)/cmd/crio-config
++	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o bin/crio-config $(PROJECT)/cmd/crio-config
+ 	( cd conmon && $(CURDIR)/bin/crio-config )
+ 
+ clean:
+@@ -156,7 +156,7 @@ bin/crio.cross.%: .gopathok .explicit_phony
+ 	TARGET="$*"; \
+ 	GOOS="$${TARGET%%.*}" \
+ 	GOARCH="$${TARGET##*.}" \
+-	$(GO) build -i $(LDFLAGS) -tags "containers_image_openpgp btrfs_noversion" -o "$@" $(PROJECT)/cmd/crio
++	$(GO) build $(LDFLAGS) -tags "containers_image_openpgp btrfs_noversion" -o "$@" $(PROJECT)/cmd/crio
+ 
+ crioimage:
+ 	$(CONTAINER_RUNTIME) build -t ${CRIO_IMAGE} .
+-- 
+2.21.0
+

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -100,6 +100,7 @@ RDEPEND="${RDEPEND}
 	app-arch/unzip
 	app-arch/zip
 	app-crypt/gnupg
+	app-crypt/gpgme
 	app-crypt/tpmpolicy
 	app-editors/vim
 	app-emulation/rkt
@@ -114,6 +115,7 @@ RDEPEND="${RDEPEND}
 	coreos-base/update-ssh-keys
 	coreos-base/update_engine
 	dev-db/etcdctl
+	dev-libs/libgpg-error
 	dev-util/strace
 	dev-vcs/git
 	net-analyzer/nmap

--- a/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
+++ b/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
@@ -33,6 +33,7 @@ RDEPEND="${RDEPEND}
 	app-arch/rpm2targz
 	app-arch/sharutils
 	app-arch/unzip
+	app-crypt/gpgme
 	app-emulation/qemu
 	coreos-base/cros-devutils[cros_host]
 	=dev-lang/python-2*
@@ -49,6 +50,7 @@ RDEPEND="${RDEPEND}
 	dev-libs/dbus-glib
 	>=dev-libs/glib-2.26.1
 	dev-libs/libgcrypt
+	dev-libs/libgpg-error
 	dev-libs/libxslt
 	dev-libs/libyaml
 	dev-libs/protobuf


### PR DESCRIPTION
There has been a corner case where `make bin/crio` failed like that:

```
go build runtime/cgo: open /usr/lib/go1.12/pkg/linux_amd64/runtime/cgo.a: permission denied
make: *** [Makefile:99: bin/crio] Error 1
```

The failure happens only under certain circumstances, for example in Jenkins pipelines, where the standard Go runtime path `/usr/lib/go1.12` is not writable for normal users like `jenkins`. On the other hand, the failure is not reproducible when testing locally, nor when testing with the root user who can write to the Go runtime path.

What happens is, the standard Go runtime sometime has incorrect timestamps or checksums of `cgo.a`, which makes `go build -i` think that it has to install its own library to the system directory. That's obviously not what the build process should do. Since Go 1.10, it's unnecessary to run `go build` with an `-i` option, because now `go build` command itself maintains a cache of recently build packages. Build speed will not be better by adding an `-i` option.

So let's remove `-i` flag from `go build`. That's actually what upstream Go maintainers recommend to do.

See also https://github.com/golang/go/issues/24674