### PR TITLE
sys-kernel/coreos-firmware: add a missing linux-info dependency

### DIFF
--- a/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
+++ b/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
-inherit savedconfig
+inherit linux-info savedconfig
 
 if [[ ${PV} == 99999999* ]]; then
 	inherit git-r3


### PR DESCRIPTION
To get pre-defined kernel-specific variables, the ebuild needs to inherit `linux-info`.
Otherwise the `$KV_FULL` simply becomes an empty string. As a result, most firmware files are not installed.