### PR TITLE
sys-kernel: fix kernel build path issues to build coreos-firmware

### DIFF
--- a/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
+++ b/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
@@ -2,6 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
+
+# Tell linux-info where to find the kernel source/build
+KERNEL_DIR="${SYSROOT}/usr/src/linux"
+KBUILD_OUTPUT="${SYSROOT}/var/cache/portage/sys-kernel/coreos-kernel"
 inherit linux-info savedconfig
 
 if [[ ${PV} == 99999999* ]]; then
@@ -21,7 +25,9 @@ LICENSE="linux-firmware ( BSD ISC MIT no-source-code ) GPL-2 GPL-2+"
 SLOT="0"
 IUSE="savedconfig"
 
-DEPEND=""
+CDEPEND=">=sys-kernel/coreos-modules-4.6.3-r1:="
+DEPEND="${CDEPEND}
+		sys-kernel/coreos-sources"
 RDEPEND="!savedconfig? (
 		!sys-firmware/alsa-firmware[alsa_cards_ca0132]
 		!sys-firmware/alsa-firmware[alsa_cards_korg1212]

--- a/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
+++ b/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
@@ -117,6 +117,7 @@ src_prepare() {
 	find * -not -type d \
 		| sort "${T}/firmware" "${T}/firmware" - \
 		| uniq -u | xargs -r rm
+	find * -type f -name "* *" -exec rm -f {} \;
 
 	default
 


### PR DESCRIPTION
In order to build `coreos-firmware` correctly, we need to set `$KERNEL_DIR` and `$KBUILD_OUTPUT` before doing `inherit linux-info`. Otherwise `$KV_FULL` ends up being an invalid path, and as a result, `coreos-firmware` becomes an empty package.

Also we should make `coreos-firmware` depend on `coreos-sources` and `coreos-modules`, to be able to get a correct list of kernel modules.

We should exclude files that does include a space character `' '` from the firmwares list, to avoid kola tests errors like the following.

```
    --- FAIL: cl.filesystem/blacklist (0.20s)
             files.go:210: Blacklisted files or directories found:
    /usr/lib64/firmware/brcm/brcmfmac43430a0-sdio.ONDA-V80 PLUS.txt
```
