### PR TITLE
app-emulation: fix path to conmon in the example crio.conf

### DIFF
--- a/app-emulation/cri-o/cri-o-1.14.4.ebuild
+++ b/app-emulation/cri-o/cri-o-1.14.4.ebuild
@@ -85,6 +85,9 @@ src_compile() {
 src_install() {
 	emake DESTDIR="${D}" PREFIX="${D}${EPREFIX}/usr" install.bin install.config install.systemd
 
+	sed -e 's:/usr/local/libexec:/usr/libexec:' \
+		-i "${ED}/etc/crio/crio.conf" || die
+
 	keepdir /etc/crio
 	mv "${ED}/etc/crio/crio.conf"{,.example} || die
 


### PR DESCRIPTION
`conmon` is installed as `/usr/libexec/crio/conmon`, so an example config of crio should also have the path without `local`.