### PR TITLE
profiles: enable selinux for tar,coreutils for sdk profile

### DIFF
--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -9,6 +9,9 @@ sys-apps/coreutils	    selinux
 # Enable SELinux for runc
 app-emulation/runc          selinux
 
+# Enable SELinux for tar
+app-arch/tar                selinux
+
 # Only ship microcode currently distributed by Intel
 # See https://bugs.gentoo.org/654638#c11 by iucode-tool maintainer
 sys-firmware/intel-microcode vanilla

--- a/profiles/coreos/amd64/sdk/package.use
+++ b/profiles/coreos/amd64/sdk/package.use
@@ -1,0 +1,5 @@
+# Enable SELinux for amd64 targets
+app-arch/tar                selinux
+sys-apps/coreutils          selinux
+coreos-base/coreos          selinux
+

--- a/profiles/coreos/amd64/sdk/use.mask
+++ b/profiles/coreos/amd64/sdk/use.mask
@@ -1,0 +1,2 @@
+# Unmask selinux so it can be enabled selectively in package.use
+-selinux


### PR DESCRIPTION
To be able to fix the issue of torcx tarballs not being able to have selinux contexts, we need to enable selinux for the sdk profile.

Also enable selinux for tar package in the generic profile.