### PR TITLE
[WIP] fix the qemu key of mantle & ignition

### DIFF
--- a/coreos-devel/mantle/mantle-9999.ebuild
+++ b/coreos-devel/mantle/mantle-9999.ebuild
@@ -11,7 +11,7 @@ COREOS_GO_MOD="vendor"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="40cf53d3d3ab7c6227ced248a0ed14c71ff6e821" # v0.13.0
+	CROS_WORKON_COMMIT="6ab0b921c50ff23b6b37bb4e85b34409e493c434" # v0.13.0
 	KEYWORDS="amd64 arm64"
 fi
 

--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -11,7 +11,7 @@ inherit coreos-go cros-workon systemd udev
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="c65e95cdaecd7268e1d345c804557a1990a66314" # tag v0.33.0
+	CROS_WORKON_COMMIT="b522f642841d8d46062743b76cba61134980dd78" # tag v0.33.0
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
_work in progress. please do not merge_

To fix a wrong key name when running a qemu VM with ignition, we need to replace `opt/com.coreos` with `opt/org.flatcar-linux`.

See also https://github.com/flatcar-linux/ignition/issues/2

This PR depends on https://github.com/flatcar-linux/coreos-overlay/pull/63.