### PR TITLE
profiles/oem-aci: bring back python 2.7 to fix oem-gce crashlooping

### DIFF
--- a/profiles/coreos/targets/generic/oem-aci/package.provided
+++ b/profiles/coreos/targets/generic/oem-aci/package.provided
@@ -2,4 +2,4 @@
 sys-auth/sssd-1.13.1
 
 # Stick to one version of Python in the ACI.
-dev-lang/python-3.6.5
+dev-lang/python-2.7


### PR DESCRIPTION
To fix the recent issues about `oem-gce.service` crashlooping, we need to bring back python 2.7 instead of 3.6.5 in `package.provided`.
Otherwise `oem-gce.service` will not start.

See also https://github.com/coreos/bugs/issues/2608,
https://github.com/coreos/coreos-overlay/pull/3746