### PR TITLE
accept_keywords for perl packages

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -53,3 +53,8 @@ dev-util/checkbashisms
 # Choose the newer spidermonkey revision to support GCC 8.3.0.
 # https://bugs.gentoo.org/686744
 =dev-lang/spidermonkey-1.8.5-r7
+
+# required by perl 5.28
+=virtual/perl-Data-Dumper-2.170.0 ~amd64
+=virtual/perl-ExtUtils-MakeMaker-7.340.0 ~amd64
+=virtual/perl-Test-Harness-3.420.0 ~amd64

--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -11,3 +11,7 @@ virtual/rust ~amd64
 # Accept go utilities
 dev-go/glide ~amd64
 dev-go/godep ~amd64
+
+virtual/perl-Data-Dumper ~amd64
+virtual/perl-ExtUtils-FileMaker ~amd64
+virtual/perl-Test-Harness ~amd64


### PR DESCRIPTION
To build Flatcar with perl 5.28.2, we need to also add some keywords for related packages.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/10.