### PR TITLE
sys-kernel: Update commit reference to match the Manifest

### DIFF
--- a/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
+++ b/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 99999999* ]]; then
 	SRC_URI=""
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git"
 else
-	GIT_COMMIT="efd2c1cc375cff1c17b4259d99a7fee240c3b510"
+	GIT_COMMIT="7ae3a09dcc7581da3fcc6c578429b89e2764a684"
 	SRC_URI="https://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-${GIT_COMMIT}.tar.gz -> linux-firmware-${PV}.tar.gz"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 mips ppc ppc64 s390 sh sparc x86"
 fi


### PR DESCRIPTION
When the Manifest was updated in
e0e285c0bf7a6953fafbe10a5539bc8c84dbf48f
the commit reference in coreos-firmware-99999999.ebuild
was still pointing to the old file.
This led to a failed download verification.

Use the commit ID which the Manifest expects to be used
for the download.