### PR TITLE
Use mantle/ignition versions which have the opt/org.flatcar-linux Ignition variable

### DIFF
--- a/coreos-devel/mantle/mantle-9999.ebuild
+++ b/coreos-devel/mantle/mantle-9999.ebuild
@@ -6,12 +6,12 @@ CROS_WORKON_PROJECT="flatcar-linux/mantle"
 CROS_WORKON_LOCALNAME="mantle"
 CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/mantle"
+COREOS_GO_MOD="vendor"
 
 if [[ "${PV}" == 9999 ]]; then
-	COREOS_GO_MOD="vendor"
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="e7983fc86fae0b77e24611c6f96da3765dc81d1d" # v0.12.0
+	CROS_WORKON_COMMIT="54ee38b425c6f493232cc75be003bbee50148504" # v0.13.0+54ee38b
 	KEYWORDS="amd64 arm64"
 fi
 

--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -11,7 +11,7 @@ inherit coreos-go cros-workon systemd udev
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="c65e95cdaecd7268e1d345c804557a1990a66314" # tag v0.33.0
+	CROS_WORKON_COMMIT="cf4f871aec3c1b9d429e5703fb4feab25ea14fd5" # tag v0.33.0
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
See https://github.com/flatcar-linux/mantle/pull/26 and https://github.com/flatcar-linux/scripts/pull/22 which in combination with this PR do what https://github.com/flatcar-linux/ignition/issues/2 did for stable/beta/alpha.
Because https://github.com/flatcar-linux/ignition/pull/4 is not merged yet, this is effectively a downgrade of Ignition. Consider to delay merging this until it can use the latest commit after https://github.com/flatcar-linux/ignition/pull/4 got merged.