### PR TITLE
profiles: add keywords for perl-Getopt-Long

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -57,4 +57,5 @@ dev-util/checkbashisms
 # required by perl 5.28
 =virtual/perl-Data-Dumper-2.170.0 ~amd64
 =virtual/perl-ExtUtils-MakeMaker-7.340.0 ~amd64
+=virtual/perl-Getopt-Long-2.500.0 ~amd64
 =virtual/perl-Test-Harness-3.420.0 ~amd64

--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -14,4 +14,5 @@ dev-go/godep ~amd64
 
 virtual/perl-Data-Dumper ~amd64
 virtual/perl-ExtUtils-FileMaker ~amd64
+virtual/perl-Getopt-Long ~amd64
 virtual/perl-Test-Harness ~amd64


### PR DESCRIPTION
We need to add the new keywords to be able to build perl 5.28.