### PR TITLE
revert perl to 5.26.1

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -57,5 +57,4 @@ dev-util/checkbashisms
 # required by perl 5.28
 =virtual/perl-Data-Dumper-2.170.0 ~amd64
 =virtual/perl-ExtUtils-MakeMaker-7.340.0 ~amd64
-=virtual/perl-Getopt-Long-2.500.0 ~amd64
 =virtual/perl-Test-Harness-3.420.0 ~amd64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -54,6 +54,12 @@ dev-util/checkbashisms
 # https://bugs.gentoo.org/686744
 =dev-lang/spidermonkey-1.8.5-r7
 
+# required by perl-File-Spec-3.670.0
+=dev-lang/perl-5.26.1-r1 ~amd64
+=dev-lang/perl-5.26.1-r2 ~amd64
+=dev-lang/perl-5.26.9999 **
+=dev-lang/perl-5.28.0 ~amd64
+
 # required by perl 5.28
 =virtual/perl-Data-Dumper-2.170.0 ~amd64
 =virtual/perl-ExtUtils-MakeMaker-7.340.0 ~amd64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -55,7 +55,6 @@ dev-util/checkbashisms
 =dev-lang/spidermonkey-1.8.5-r7
 
 # required by perl 5.28
-=dev-lang/perl-5.28.9999 **
 =virtual/perl-Data-Dumper-2.170.0 ~amd64
 =virtual/perl-ExtUtils-MakeMaker-7.340.0 ~amd64
 =virtual/perl-Getopt-Long-2.500.0 ~amd64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -55,9 +55,8 @@ dev-util/checkbashisms
 =dev-lang/spidermonkey-1.8.5-r7
 
 # required by perl 5.28
-=dev-lang/perl-5.28.2-r1 **
+=dev-lang/perl-5.28.9999 **
 =virtual/perl-Data-Dumper-2.170.0 ~amd64
 =virtual/perl-ExtUtils-MakeMaker-7.340.0 ~amd64
-=virtual/perl-File-Spec-3.740.0 ~amd64
 =virtual/perl-Getopt-Long-2.500.0 ~amd64
 =virtual/perl-Test-Harness-3.420.0 ~amd64

--- a/profiles/coreos/base/package.mask
+++ b/profiles/coreos/base/package.mask
@@ -18,9 +18,3 @@
 # Since version 2, it tries to write liblto symlinks with absolute paths that
 # don't work when building for the board root directories.
 >=sys-devel/gcc-config-2
-
-# Disable perl 5.26 or older, as well as 5.30 or newer to avoid slot conflicts.
-<dev-lang/perl-5.28
->=dev-lang/perl-5.30.0
->=virtual/perl-Data-Dumper-2.174.0
->=virtual/perl-File-Spec-3.780.0

--- a/profiles/coreos/base/package.mask
+++ b/profiles/coreos/base/package.mask
@@ -18,3 +18,12 @@
 # Since version 2, it tries to write liblto symlinks with absolute paths that
 # don't work when building for the board root directories.
 >=sys-devel/gcc-config-2
+
+# required by perl 5.26.1
+>=dev-lang/perl-5.26.9999
+>=virtual/perl-Data-Dumper-2.170.0
+>=virtual/perl-ExtUtils-MakeMaker-7.340.0
+>=virtual/perl-File-Path-2.150.0
+>=virtual/perl-File-Spec-3.740.0
+>=virtual/perl-Getopt-Long-2.500.0
+>=virtual/perl-Test-Harness-3.420.0

--- a/profiles/coreos/base/package.unmask
+++ b/profiles/coreos/base/package.unmask
@@ -1,0 +1,2 @@
+=dev-lang/perl-5.26.1-r1
+=dev-lang/perl-5.26.1-r2

--- a/profiles/coreos/targets/generic/package.mask
+++ b/profiles/coreos/targets/generic/package.mask
@@ -1,0 +1,8 @@
+# required by perl 5.26.1
+>=dev-lang/perl-5.26.9999
+>=virtual/perl-Data-Dumper-2.170.0
+>=virtual/perl-ExtUtils-MakeMaker-7.340.0
+>=virtual/perl-File-Path-2.150.0
+>=virtual/perl-File-Spec-3.740.0
+>=virtual/perl-Getopt-Long-2.500.0
+>=virtual/perl-Test-Harness-3.420.0

--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -14,5 +14,4 @@ dev-go/godep ~amd64
 
 virtual/perl-Data-Dumper ~amd64
 virtual/perl-ExtUtils-FileMaker ~amd64
-virtual/perl-Getopt-Long ~amd64
 virtual/perl-Test-Harness ~amd64

--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -15,6 +15,5 @@ dev-go/godep ~amd64
 dev-lang/perl ~amd64
 virtual/perl-Data-Dumper ~amd64
 virtual/perl-ExtUtils-FileMaker ~amd64
-virtual/perl-File-Spec ~amd64
 virtual/perl-Getopt-Long ~amd64
 virtual/perl-Test-Harness ~amd64

--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -12,6 +12,11 @@ virtual/rust ~amd64
 dev-go/glide ~amd64
 dev-go/godep ~amd64
 
+=dev-lang/perl-5.26.1-r1 ~amd64
+=dev-lang/perl-5.26.1-r2 ~amd64
+=dev-lang/perl-5.26.9999 **
+=dev-lang/perl-5.28.0 ~amd64
+
 virtual/perl-Data-Dumper ~amd64
 virtual/perl-ExtUtils-FileMaker ~amd64
 virtual/perl-Test-Harness ~amd64

--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -12,7 +12,6 @@ virtual/rust ~amd64
 dev-go/glide ~amd64
 dev-go/godep ~amd64
 
-dev-lang/perl ~amd64
 virtual/perl-Data-Dumper ~amd64
 virtual/perl-ExtUtils-FileMaker ~amd64
 virtual/perl-Getopt-Long ~amd64

--- a/profiles/coreos/targets/sdk/package.mask
+++ b/profiles/coreos/targets/sdk/package.mask
@@ -1,0 +1,8 @@
+# required by perl 5.26.1
+>=dev-lang/perl-5.26.9999
+>=virtual/perl-Data-Dumper-2.170.0
+>=virtual/perl-ExtUtils-MakeMaker-7.340.0
+>=virtual/perl-File-Path-2.150.0
+>=virtual/perl-File-Spec-3.740.0
+>=virtual/perl-Getopt-Long-2.500.0
+>=virtual/perl-Test-Harness-3.420.0

--- a/profiles/coreos/targets/sdk/package.unmask
+++ b/profiles/coreos/targets/sdk/package.unmask
@@ -1,0 +1,2 @@
+=dev-lang/perl-5.26.1-r1
+=dev-lang/perl-5.26.1-r2


### PR DESCRIPTION
To unblock other builds, let's revert perl back to 5.26.1.

together with https://github.com/flatcar-linux/portage-stable/pull/12