### PR TITLE
app-emulation/cri-o: fix path prefix in crio-wipe.service

### DIFF
--- a/app-emulation/cri-o/cri-o-1.15.2.ebuild
+++ b/app-emulation/cri-o/cri-o-1.15.2.ebuild
@@ -83,6 +83,9 @@ src_install() {
 	sed -e 's:/usr/local/libexec:/usr/libexec:' \
 		-i "${ED}/etc/crio/crio.conf" || die
 
+	sed -e 's:/usr/local/libexec:/usr/libexec:' \
+		-i "${ED}/usr/lib/systemd/system/crio-wipe.service" || die
+
 	keepdir /etc/crio
 	mv "${ED}/etc/crio/crio.conf"{,.example} || die
 


### PR DESCRIPTION
We should replace `/usr/local/libexec` with `/usr/libexec` also in `crio-wipe.service`.
Otherwise `crio-wipe.service` will not start at all.

Fixes https://github.com/flatcar-linux/Flatcar/issues/9