### PR TITLE
net-libs/rpcsvc-proto: make rpcgen work for both architectures

### DIFF
--- a/net-libs/rpcsvc-proto/files/rpcsvc-proto-1.3.1-rpcgen-from-host.patch
+++ b/net-libs/rpcsvc-proto/files/rpcsvc-proto-1.3.1-rpcgen-from-host.patch
@@ -16,7 +16,7 @@ index 83867c0..c1610a7 100644
  
  %.h: %.x
 -	$(top_builddir)/rpcgen/rpcgen -h -o $@ $<
-+	rpcgen -h -o $@ $<
++	$(top_builddir)/rpcgen/rpcgen -h -o $@ $< || /usr/bin/rpcgen -h -o $@ $<
  
 -- 
 2.21.0


### PR DESCRIPTION
`rpcsvc-proto` started failing due to a missing binary `rpcgen`, during the Jenkins pipeline for SDK.

We need to have a fallback mechanism for trying both the built-in rpcgen and the host rpcgen.