### PR TITLE
[WIP] profiles: enable sssd only for sudo on amd64 to avoid talloc failures

### DIFF
--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -15,3 +15,5 @@ app-arch/tar                selinux
 # Only ship microcode currently distributed by Intel
 # See https://bugs.gentoo.org/654638#c11 by iucode-tool maintainer
 sys-firmware/intel-microcode vanilla
+
+app-admin/sudo		    sssd

--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 The Chromium OS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 
-app-admin/sudo		ldap sssd
+app-admin/sudo		ldap
 app-editors/vim		minimal
 dev-lang/python		-berkdb gdbm
 dev-libs/dbus-glib	tools


### PR DESCRIPTION
_Work-in-progress: still testing_

Jenkins pipeline for arm64 started failing with `sys-libs/talloc`, which depends on the build system `waf`. When running `configure` script, `waf` tries to run a cross-compiled binary, which fails with `Exec format error`.

Unfortunately waf is not able to deal with running tests with cross-built binaries, when no `qemu-aarch64-static` is installed on the host system. Since the Jenkins worker is a minimal Flatcar system, we cannot simply install a qemu static package on the system. Also there is no simple way to disable running such tests in talloc and waf.

So for now, we should enable `sssd` for `sudo` only for `amd64`, not for `arm64`. Then sudo for arm64 will not pull the new dependencies like `talloc`.