### PR TITLE
dev-lang/rust: store shell scripts under source dir instead of /tmp

### DIFF
--- a/dev-lang/rust/rust-1.36.0.ebuild
+++ b/dev-lang/rust/rust-1.36.0.ebuild
@@ -219,14 +219,14 @@ src_configure() {
 		fi
 	done
 	if [ -f /usr/bin/aarch64-cros-linux-gnu-gcc ]; then
-		printf '#!/bin/sh\naarch64-cros-linux-gnu-gcc --sysroot=/usr/aarch64-cros-linux-gnu "$@"' > /tmp/cc.sh
-		printf '#!/bin/sh\naarch64-cros-linux-gnu-g++ --sysroot=/usr/aarch64-cros-linux-gnu "$@"' > /tmp/cxx.sh
-		chmod +x /tmp/cc.sh /tmp/cxx.sh
+		printf '#!/bin/sh\naarch64-cros-linux-gnu-gcc --sysroot=/usr/aarch64-cros-linux-gnu "$@"' > ${S}/cc.sh
+		printf '#!/bin/sh\naarch64-cros-linux-gnu-g++ --sysroot=/usr/aarch64-cros-linux-gnu "$@"' > ${S}/cxx.sh
+		chmod +x ${S}/cc.sh ${S}/cxx.sh
 		cat <<- EOF >> "${S}"/config.toml
 			[target.aarch64-unknown-linux-gnu]
-			cc = "/tmp/cc.sh"
-			cxx = "/tmp/cxx.sh"
-			linker = "/tmp/cc.sh"
+			cc = "${S}/cc.sh"
+			cxx = "${S}/cxx.sh"
+			linker = "${S}/cc.sh"
 			ar = "aarch64-cros-linux-gnu-ar"
 		EOF
 	fi


### PR DESCRIPTION
When building ebuilds under catalyst stage4, emerge cannot write data outside of its chroot, under `/tmp` on the host.
That's the reason why the rust installation from toolchain fails like `/tmp/cc.sh: Permission denied`.

That is no issue when building it under local SDK, because in that case there is no toolchain installation involved.

So we should write the temporary scripts under `${S}`, for example, `/mnt/host/source/src/build/catalyst/tmp/coreos-toolchains/stage4-amd64-2303.2.1/`.