### PR TITLE
profiles: add libselinux keywords to the base profile

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -67,3 +67,6 @@ dev-util/checkbashisms
 =sys-auth/google-oslogin-20180611 **
 
 =sys-process/tini-0.18.0 ~arm64
+
+=sys-libs/libsepol-2.4 **
+=sys-libs/libselinux-2.4 **


### PR DESCRIPTION
So far libselinux was not installed for arm64, because it was simply masked.

We need to enable keywords for both libselinux and libsepol, to correctly build arm64 images including SELinux libs and binaries.