### PR TITLE
coreos-base/oem-gce: Fix resolving metadata.google.internal via /etc/hosts

### DIFF
--- a/coreos-base/oem-gce/files/files/hosts
+++ b/coreos-base/oem-gce/files/files/hosts
@@ -1,2 +1,2 @@
-169.254.169.254 metadata
+169.254.169.254 metadata metadata.google.internal
 127.0.0.1 localhost

--- a/coreos-base/oem-gce/files/units/oem-gce.service
+++ b/coreos-base/oem-gce/files/units/oem-gce.service
@@ -19,6 +19,8 @@ ExecStart=/usr/bin/rkt run \
     --volume=etc,kind=host,source=/etc,readOnly=false \
     --volume=home,kind=host,source=/home,readOnly=false \
     --volume=runsystemd,kind=host,source=/run/systemd,readOnly=false \
+    --volume=nsswitch,kind=host,source=/usr/share/google-oslogin/nsswitch.conf,readOnly=true \
+    --mount=volume=nsswitch,target=/usr/share/google-oslogin/nsswitch.conf \
     /usr/share/oem/flatcar-oem-gce.aci
 
 ExecStopPost=/usr/bin/rkt gc --mark-only


### PR DESCRIPTION
When a custom DNS server is used on the system, the oem-gce
container cannot resolve metadata.google.internal anymore.

- Add metadata.google.internal to /etc/hosts.
- Bind mount nsswitch.conf for /etc/hosts because
    the host's /etc/nsswitch.conf is a symlink to
    /usr/share/google-oslogin/nsswitch.conf
    but that is not present in the rkt container.
    Do not only bind-mount /etc but also the target
    of the symlink. With a broken nsswitch.conf
    any entries in /etc/hosts are not considered
    which makes problems when a custom DNS server
    is used.

Note: Should be merged for alpha and edge as well.