### PR TITLE
app-arch/torcx: Fix wrong profile reference

### DIFF
--- a/app-arch/torcx/files/docker-1.12-no.json
+++ b/app-arch/torcx/files/docker-1.12-no.json
@@ -4,7 +4,7 @@
         "images": [
             {
                 "name": "docker",
-                "reference": "18.06"
+                "reference": "19.03"
             }
         ]
     }


### PR DESCRIPTION
When /etc/flatcar/docker-1.12 contains "no"
the profile for 18.06 was searched for instead
of 19.03. Keep docker-1.12-no.json in sync
with the latest version in app-torcx/docker/files/.

**Note:** Should be cherry-picked for alpha flatcar-build-2387(.0.0) as well.