### PR TITLE
Use rkt again instead of docker in etcd/flannel-wrappers for Edge

### DIFF
--- a/app-admin/etcd-wrapper/etcd-wrapper-3.3.18.ebuild
+++ b/app-admin/etcd-wrapper/etcd-wrapper-3.3.18.ebuild
@@ -14,6 +14,7 @@ IUSE=""
 SLOT=0
 
 DEPEND=""
+RDEPEND=">=app-emulation/rkt-1.9.1[rkt_stage1_fly]"
 
 S=${WORKDIR}
 

--- a/app-admin/etcd-wrapper/files/etcd-member.service
+++ b/app-admin/etcd-wrapper/files/etcd-member.service
@@ -7,7 +7,7 @@ Conflicts=etcd.service
 Conflicts=etcd2.service
 
 [Service]
-Type=simple
+Type=notify
 Restart=on-failure
 RestartSec=10s
 TimeoutStartSec=0
@@ -17,11 +17,12 @@ Environment="ETCD_IMAGE_TAG=@ETCD_IMAGE_TAG@"
 Environment="ETCD_NAME=%m"
 Environment="ETCD_USER=etcd"
 Environment="ETCD_DATA_DIR=/var/lib/etcd"
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/lib/flatcar/etcd-member-wrapper.uuid"
 
 ExecStartPre=/usr/bin/mkdir --parents /var/lib/flatcar
-ExecStartPre=-/usr/bin/docker rm --force etcd-docker
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/flatcar/etcd-member-wrapper.uuid
 ExecStart=/usr/lib/flatcar/etcd-wrapper $ETCD_OPTS
-ExecStop=-/usr/bin/docker stop etcd-docker
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/flatcar/etcd-member-wrapper.uuid
 
 [Install]
 WantedBy=multi-user.target

--- a/app-admin/etcd-wrapper/files/etcd-wrapper
+++ b/app-admin/etcd-wrapper/files/etcd-wrapper
@@ -1,5 +1,5 @@
 #!/usr/bin/bash -e
-# Wrapper for launching etcd via docker.
+# Wrapper for launching etcd via rkt.
 #
 # Make sure to set ETCD_IMAGE_TAG to an image tag published here:
 # https://quay.io/repository/coreos/etcd?tab=tags Alternatively,
@@ -30,6 +30,10 @@ require_ev_all ETCD_USER ETCD_DATA_DIR
 ETCD_IMAGE_URL="${ETCD_IMAGE_URL:-quay.io/coreos/etcd}"
 ETCD_IMAGE="${ETCD_IMAGE:-${ETCD_IMAGE_URL}:${ETCD_IMAGE_TAG}}"
 
+if [[ "${ETCD_IMAGE%%/*}" == "quay.io" ]]; then
+	RKT_RUN_ARGS="${RKT_RUN_ARGS} --trust-keys-from-https"
+fi
+
 if [[ ! -e "${ETCD_DATA_DIR}" ]]; then
 	mkdir --parents "${ETCD_DATA_DIR}"
 	chown "${ETCD_USER}" "${ETCD_DATA_DIR}"
@@ -44,29 +48,38 @@ ETCD_SSL_DIR="${ETCD_SSL_DIR:-/etc/ssl/certs}"
 
 SYSTEMD_SYSTEM_DIR_SRC="${SYSTEMD_SYSTEM_DIR_SRC:-/run/systemd/system}"
 if [[ -d "${SYSTEMD_SYSTEM_DIR_SRC}" ]]; then
-	DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} \
-		--mount type=bind,bind-propagation=rprivate,source=/run/systemd/system,target=/run/systemd/system,readonly \
+	RKT_RUN_ARGS="${RKT_RUN_ARGS} \
+		--mount volume=coreos-systemd-dir,target=/run/systemd/system \
+		--volume coreos-systemd-dir,kind=host,source=${SYSTEMD_SYSTEM_DIR_SRC},readOnly=true \
 	"
 fi
 
 if [[ -S "${NOTIFY_SOCKET}" ]]; then
-	DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} \
-		--env NOTIFY_SOCKET=/run/systemd/notify \
-		--mount type=bind,bind-propagation=rprivate,source=/run/systemd/notify,target=/run/systemd/notify \
+	RKT_RUN_ARGS="${RKT_RUN_ARGS} \
+		--mount volume=coreos-notify,target=/run/systemd/notify \
+		--volume coreos-notify,kind=host,source=${NOTIFY_SOCKET} \
+		--set-env=NOTIFY_SOCKET=/run/systemd/notify \
 	"
 fi
 
-DOCKER="${DOCKER:-/usr/bin/docker}"
+RKT="${RKT:-/usr/bin/rkt}"
+RKT_STAGE1_ARG="${RKT_STAGE1_ARG:---stage1-from-dir=stage1-fly.aci}"
 set -x
-exec ${DOCKER} ${DOCKER_GLOBAL_ARGS} \
-	run ${DOCKER_RUN_ARGS} \
-	--name=etcd-docker --entrypoint=/usr/local/bin/etcd \
-	--mount type=bind,bind-propagation=rshared,source=${etcd_data_dir},target=/var/lib/etcd \
-	--mount type=bind,bind-propagation=rprivate,source=${ETCD_SSL_DIR},target=/etc/ssl/certs,readonly \
-	--mount type=bind,bind-propagation=rprivate,source=/usr/share/ca-certificates,target=/usr/share/ca-certificates,readonly \
-	--mount type=bind,bind-propagation=rprivate,source=/etc/hosts,target=/etc/hosts,readonly \
-	--mount type=bind,bind-propagation=rprivate,source=/etc/resolv.conf,target=/etc/resolv.conf,readonly \
-	--user=$(id -u "${ETCD_USER}") \
+exec ${RKT} ${RKT_GLOBAL_ARGS} \
+	run ${RKT_RUN_ARGS} \
+	--volume coreos-data-dir,kind=host,source="${etcd_data_dir}",readOnly=false \
+	--volume coreos-etc-ssl-certs,kind=host,source="${ETCD_SSL_DIR}",readOnly=true \
+	--volume coreos-usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
+	--volume coreos-etc-hosts,kind=host,source=/etc/hosts,readOnly=true \
+	--volume coreos-etc-resolv,kind=host,source=/etc/resolv.conf,readOnly=true \
+	--mount volume=coreos-data-dir,target=/var/lib/etcd \
+	--mount volume=coreos-etc-ssl-certs,target=/etc/ssl/certs \
+	--mount volume=coreos-usr-share-certs,target=/usr/share/ca-certificates \
+	--mount volume=coreos-etc-hosts,target=/etc/hosts  \
+	--mount volume=coreos-etc-resolv,target=/etc/resolv.conf  \
+	--inherit-env \
+	${RKT_STAGE1_ARG} \
 	${ETCD_IMAGE} \
 		${ETCD_IMAGE_ARGS} \
-		--data-dir=/var/lib/etcd "$@"
+		--user=$(id -u "${ETCD_USER}") \
+		-- "$@"

--- a/app-admin/flannel-wrapper/files/flannel-docker-opts.service
+++ b/app-admin/flannel-wrapper/files/flannel-docker-opts.service
@@ -9,12 +9,13 @@ Before=docker.service
 [Service]
 Type=oneshot
 
-Environment="DOCKER_RUN_ARGS=--name=flannel-docker"
 Environment="FLANNEL_IMAGE_TAG=@FLANNEL_IMAGE_TAG@"
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/lib/flatcar/flannel-wrapper2.uuid"
+Environment="FLANNEL_IMAGE_ARGS=--exec=/opt/bin/mk-docker-opts.sh"
 
-ExecStartPre=-/usr/bin/docker rm --force flannel-docker
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/flatcar/flannel-wrapper2.uuid
 ExecStart=/usr/lib/flatcar/flannel-wrapper -d /run/flannel/flannel_docker_opts.env -i
-ExecStop=-/usr/bin/docker stop flannel-docker
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/flatcar/flannel-wrapper2.uuid
 
 [Install]
 WantedBy=multi-user.target

--- a/app-admin/flannel-wrapper/files/flannel-wrapper
+++ b/app-admin/flannel-wrapper/files/flannel-wrapper
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Wrapper for launching flannel via docker.
+# Wrapper for launching flannel via rkt.
 #
 # Make sure to set FLANNEL_IMAGE_TAG to an image tag published here:
 # https://quay.io/repository/coreos/flannel?tab=tags Alternatively,
@@ -39,33 +39,46 @@ require_ev_one FLANNEL_IMAGE FLANNEL_IMAGE_TAG
 FLANNEL_IMAGE_URL="${FLANNEL_IMAGE_URL:-${FLANNEL_IMG:-quay.io/coreos/flannel}}"
 FLANNEL_IMAGE="${FLANNEL_IMAGE:-${FLANNEL_IMAGE_URL}:${FLANNEL_IMAGE_TAG}}"
 
+if [[ "${FLANNEL_IMAGE%%/*}" == "quay.io" ]]; then
+	RKT_RUN_ARGS="${RKT_RUN_ARGS} --trust-keys-from-https"
+fi
+
 ETCD_SSL_DIR="${ETCD_SSL_DIR:-/etc/ssl/etcd}"
 if [[ -d "${ETCD_SSL_DIR}" ]]; then
-	DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} \
-		--mount type=bind,bind-propagation=rprivate,source=${ETCD_SSL_DIR},target=${ETCD_SSL_DIR},readonly \
+	RKT_RUN_ARGS="${RKT_RUN_ARGS} \
+		--volume coreos-ssl,kind=host,source=${ETCD_SSL_DIR},readOnly=true \
+		--mount volume=coreos-ssl,target=${ETCD_SSL_DIR} \
 	"
 fi
 
 if [[ -S "${NOTIFY_SOCKET}" ]]; then
-	DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} \
-		--env NOTIFY_SOCKET=/run/systemd/notify \
-		--mount type=bind,bind-propagation=rprivate,source=${NOTIFY_SOCKET},target=/run/systemd/notify \
+	RKT_RUN_ARGS="${RKT_RUN_ARGS} \
+		--mount volume=coreos-notify,target=/run/systemd/notify \
+		--volume coreos-notify,kind=host,source=${NOTIFY_SOCKET} \
+		--set-env=NOTIFY_SOCKET=/run/systemd/notify \
 	"
 fi
 
 mkdir --parents /run/flannel
 
-DOCKER="${DOCKER:-/usr/bin/docker}"
+RKT="${RKT:-/usr/bin/rkt}"
+RKT_STAGE1_ARG="${RKT_STAGE1_ARG:---stage1-from-dir=stage1-fly.aci}"
 set -x
-exec ${DOCKER} ${DOCKER_GLOBAL_ARGS} \
-	run ${DOCKER_RUN_ARGS} \
-	--entrypoint=/opt/bin/flanneld \
+exec ${RKT} ${RKT_GLOBAL_ARGS} \
+	run ${RKT_RUN_ARGS} \
 	--net=host \
-	--mount type=bind,bind-propagation=rprivate,source=/run/flannel,target=/run/flannel \
-	--mount type=bind,bind-propagation=rprivate,source=/etc/ssl/certs,target=/etc/ssl/certs,readonly \
-	--mount type=bind,bind-propagation=rprivate,source=/usr/share/ca-certificates,target=/usr/share/ca-certificates,readonly \
-	--mount type=bind,bind-propagation=rprivate,source=/etc/hosts,target=/etc/hosts,readonly \
-	--mount type=bind,bind-propagation=rprivate,source=/etc/resolv.conf,target=/etc/resolv.conf,readonly \
+	--volume coreos-run-flannel,kind=host,source=/run/flannel,readOnly=false \
+	--volume coreos-etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \
+	--volume coreos-usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
+	--volume coreos-etc-hosts,kind=host,source=/etc/hosts,readOnly=true \
+	--volume coreos-etc-resolv,kind=host,source=/etc/resolv.conf,readOnly=true \
+	--mount volume=coreos-run-flannel,target=/run/flannel \
+	--mount volume=coreos-etc-ssl-certs,target=/etc/ssl/certs \
+	--mount volume=coreos-usr-share-certs,target=/usr/share/ca-certificates \
+	--mount volume=coreos-etc-hosts,target=/etc/hosts  \
+	--mount volume=coreos-etc-resolv,target=/etc/resolv.conf \
+	--inherit-env \
+	${RKT_STAGE1_ARG} \
 	${FLANNEL_IMAGE} \
 		${FLANNEL_IMAGE_ARGS} \
-		"$@"
+		-- "$@"

--- a/app-admin/flannel-wrapper/files/flanneld.service
+++ b/app-admin/flannel-wrapper/files/flanneld.service
@@ -5,23 +5,23 @@ After=etcd.service etcd2.service etcd-member.service
 Requires=flannel-docker-opts.service
 
 [Service]
-Type=simple
+Type=notify
 Restart=always
 RestartSec=10s
 TimeoutStartSec=300
 LimitNOFILE=40000
 LimitNPROC=1048576
 
-Environment="DOCKER_RUN_ARGS=--name=flanneld-docker"
 Environment="FLANNEL_IMAGE_TAG=@FLANNEL_IMAGE_TAG@"
 Environment="FLANNEL_OPTS=--ip-masq=true"
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/lib/flatcar/flannel-wrapper.uuid"
 EnvironmentFile=-/run/flannel/options.env
 
 ExecStartPre=/sbin/modprobe ip_tables
 ExecStartPre=/usr/bin/mkdir --parents /var/lib/flatcar /run/flannel
-ExecStartPre=-/usr/bin/docker rm --force flanneld-docker
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/flatcar/flannel-wrapper.uuid
 ExecStart=/usr/lib/flatcar/flannel-wrapper $FLANNEL_OPTS
-ExecStop=-/usr/bin/docker stop flanneld-docker
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/flatcar/flannel-wrapper.uuid
 
 [Install]
 WantedBy=multi-user.target

--- a/app-admin/flannel-wrapper/flannel-wrapper-0.11.0.ebuild
+++ b/app-admin/flannel-wrapper/flannel-wrapper-0.11.0.ebuild
@@ -17,6 +17,7 @@ IUSE=""
 
 RDEPEND="
 	!app-admin/flannel
+	>=app-emulation/rkt-1.9.1[rkt_stage1_fly]
 "
 
 S="$WORKDIR"

--- a/app-admin/toolbox/toolbox-9999.ebuild
+++ b/app-admin/toolbox/toolbox-9999.ebuild
@@ -23,6 +23,8 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE=""
 
+RDEPEND="app-emulation/rkt"
+
 src_install() {
 	dobin ${S}/toolbox
 }


### PR DESCRIPTION
We replaced rkt with docker via https://github.com/flatcar-linux/coreos-overlay/pull/103 for Edge, and later got it back to docker via https://github.com/flatcar-linux/coreos-overlay/pull/148.
However, we did not revert commits for other wrappers, like etcd-wrapper or flannel-wrapper.
Let's do the revert for other wrappers as well, to unbreak issues around etcd, which happened with Lokomotive clusters recently.
