### PR TITLE
coreos-base/afterburn: Create symlink for /run/metadata/coreos

### DIFF
--- a/coreos-base/afterburn/files/coreos-metadata.service
+++ b/coreos-base/afterburn/files/coreos-metadata.service
@@ -5,6 +5,7 @@ Description=Flatcar Metadata Agent
 Type=oneshot
 Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
 ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
+ExecStartPost=ln -fs /run/metadata/flatcar /run/metadata/coreos
 
 [Install]
 RequiredBy=metadata.target


### PR DESCRIPTION
Only the file /run/metadata/flatcar was created but
for compatibility we should also keep a symlink to it
at /run/metadata/coreos.

Note: Should also be picked for alpha and edge.