### PR TITLE
profiles: enable static-libs for dev-libs/elfutils

### DIFF
--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -5,7 +5,7 @@ app-admin/sudo		ldap sssd
 app-editors/vim		minimal
 dev-lang/python		-berkdb gdbm
 dev-libs/dbus-glib	tools
-dev-libs/elfutils	-utils
+dev-libs/elfutils	static-libs -utils
 dev-libs/nss		-utils
 dev-libs/openssl	pkcs11
 dev-util/perf		-doc -demangle -tui -ncurses -perl -python

--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -13,6 +13,7 @@ app-crypt/gnupg smartcard usb
 # for qemu
 app-arch/bzip2 static-libs
 app-emulation/qemu static-user
+dev-libs/elfutils static-libs
 dev-libs/glib static-libs
 dev-libs/libaio static-libs
 dev-libs/libpcre static-libs


### PR DESCRIPTION
Unlike elfutils 0.169, elfutils 0.178 does not install its static library `libelf.a`, unless a USE flag `static-libs` is specified.

We need to enable `static-libs` for `dev-libs/elfutils`, to avoid build errors from packages like bpftool.