### PR TITLE
.github: schedule daily Github actions for Kernel

### DIFF
--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+branch="linux-${VERSION_NEW}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
+git checkout -B "${branch}" "github/${BASE_BRANCH}"
+
+versionOld=$(sed -n "s/^DIST patch-\(${KERNEL_VERSION}.[0-9]*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
+[[ "${VERSION_NEW}" = "$versionOld" ]] && echo "already the latest Kernel, nothing to do" && exit 1
+
+for pkg in sources modules kernel; do \
+  pushd "sys-kernel/coreos-${pkg}" >/dev/null || exit; \
+  git mv "coreos-${pkg}"-*.ebuild "coreos-${pkg}-${VERSION_NEW}.ebuild"; \
+  sed -i -e '/^COREOS_SOURCE_REVISION=/s/=.*/=""/' "coreos-${pkg}-${VERSION_NEW}.ebuild"; \
+  popd >/dev/null || exit; \
+done
+
+( cd ../../..; exec cork enter -- ebuild "/mnt/host/source/src/third_party/coreos-overlay/sys-kernel/coreos-sources/coreos-sources-${VERSION_NEW}.ebuild" manifest --force )
+
+# We can only create the actual commit in the actual source directory, not under the SDK.
+# So create a format-patch, and apply to the actual source.
+git add sys-kernel/coreos-*
+git commit -a -m "sys-kernel/coreos-sources: Upgrade Linux ${versionOld} to ${VERSION_NEW}"
+git format-patch -1 --stdout HEAD > "${branch}".patch
+popd || exit
+
+git config user.name 'Flatcar Buildbot'
+git config user.email 'buildbot@flatcar-linux.org'
+git reset --hard HEAD
+git fetch origin
+git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+git am ~/flatcar-sdk/src/third_party/coreos-overlay/"${branch}".patch
+
+echo ::set-output name=VERSION_OLD::"${versionOld}"

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -1,0 +1,47 @@
+name: Get the latest Kernel release for Alpha
+on:
+  schedule:
+    - cron:  '0 7 * * *'
+
+jobs:
+  get-kernel-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Kernel release
+        id: fetch-latest-release
+        env:
+          KV_ALPHA: 4.19
+        run: |
+          git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
+          versionAlpha=$(git -C linux tag | sed -n "/^v${KV_ALPHA}.[0-9]*$/s/^v//p" | sort -ruV | head -1)
+          rm -rf linux
+          echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
+          echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Alpha
+        id: apply-patch-alpha
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          KERNEL_VERSION: 4.19
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+        run: .github/workflows/kernel-apply-patch.sh
+      - name: Create pull request for Alpha
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          branch: linux-${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}-alpha
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Linux Kernel in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          commit-message: Upgrade Linux Kernel in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          body: Upgrade Linux Kernel in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          labels: alpha

--- a/.github/workflows/kernel-releases-edge.yml
+++ b/.github/workflows/kernel-releases-edge.yml
@@ -1,0 +1,47 @@
+name: Get the latest Kernel release for Edge
+on:
+  schedule:
+    - cron:  '0 7 * * *'
+
+jobs:
+  get-kernel-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Kernel release
+        id: fetch-latest-release
+        env:
+          KV_EDGE: 5.5
+        run: |
+          git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
+          versionEdge=$(git -C linux tag | sed -n "/^v${KV_EDGE}.[0-9]*$/s/^v//p" | sort -ruV | head -1)
+          rm -rf linux
+          echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
+          echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Edge
+        id: apply-patch-edge
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          KERNEL_VERSION: 5.5
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+        run: .github/workflows/kernel-apply-patch.sh
+      - name: Create pull request for Edge
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          branch: linux-${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}-edge
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Linux Kernel in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          commit-message: Upgrade Linux Kernel in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          body: Upgrade Linux Kernel in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          labels: edge

--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64
+curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64.sig
+gpg --keyserver keys.gnupg.net --receive-keys 84C8E771C0DF83DFBFCAAAF03ADA89DEC2507883
+gpg --verify cork.sig cork
+rm -f cork.sig
+chmod +x cork
+mkdir -p ~/.local/bin
+mv cork ~/.local/bin
+
+export PATH=$PATH:$HOME/.local/bin
+mkdir -p ~/flatcar-sdk
+
+pushd ~/flatcar-sdk || exit
+cork create || true
+
+# /var under the chroot has to be writable by the runner user
+sudo chown -R runner:docker ~/flatcar-sdk/chroot/var
+
+git -C src/third_party/coreos-overlay reset --hard github/flatcar-master
+git -C src/third_party/coreos-overlay config user.name 'Flatcar Buildbot'
+git -C src/third_party/coreos-overlay config user.email 'buildbot@flatcar-linux.org'
+popd || exit
+
+echo ::set-output name=path::"${PATH}"


### PR DESCRIPTION
This PR add 2 different Github actions that run once in a day, one for Alpha, Kernel 4.19, and the other for Edge, Kernel 5.5.

Because of limitations of Github Actions, i.e. create-pull-request actions, we cannot combine the two actions into one. Also we need to create a patch and apply it to the top source directory, since the create-pull-request action requires the changes in the top
directory.

Although we are not updating `flatcar-master` branch, (only Alpha and Edge) the Github actions files need to be merged to `flatcar-master`, because Github actions can only schedule cron jobs from the default branch, `flatcar-master`.