### PR TITLE
app-emulation/docker-runc: Disable SELinux warnings

### DIFF
--- a/app-emulation/docker-runc/docker-runc-1.0.0_rc10.ebuild
+++ b/app-emulation/docker-runc/docker-runc-1.0.0_rc10.ebuild
@@ -43,6 +43,7 @@ src_unpack() {
 
 PATCHES=(
 	"${FILESDIR}/0001-Delay-unshare-of-clone-newipc-for-selinux.patch"
+	"${FILESDIR}/0001-temporarily-disable-selinux.GetEnabled-error-checks.patch"
 )
 
 src_compile() {

--- a/app-emulation/docker-runc/files/0001-temporarily-disable-selinux.GetEnabled-error-checks.patch
+++ b/app-emulation/docker-runc/files/0001-temporarily-disable-selinux.GetEnabled-error-checks.patch
@@ -1,0 +1,58 @@
+From 7264883458e7bdcd23152495ac141a24d17b8db9 Mon Sep 17 00:00:00 2001
+Message-Id: <7264883458e7bdcd23152495ac141a24d17b8db9.1564136934.git.dongsu@kinvolk.io>
+From: Dongsu Park <dongsu@kinvolk.io>
+Date: Fri, 26 Jul 2019 12:19:37 +0200
+Subject: [PATCH] temporarily disable selinux.GetEnabled() error checks
+
+---
+ libcontainer/configs/validate/validator.go | 4 ----
+ utils_linux.go                             | 4 ----
+ 2 files changed, 8 deletions(-)
+
+diff --git a/libcontainer/configs/validate/validator.go b/libcontainer/configs/validate/validator.go
+index 3b42f301..bace067d 100644
+--- a/libcontainer/configs/validate/validator.go
++++ b/libcontainer/configs/validate/validator.go
+@@ -8,7 +8,6 @@ import (
+ 
+ 	"github.com/opencontainers/runc/libcontainer/configs"
+ 	"github.com/opencontainers/runc/libcontainer/intelrdt"
+-	selinux "github.com/opencontainers/selinux/go-selinux"
+ )
+ 
+ type Validator interface {
+@@ -99,9 +98,6 @@ func (v *ConfigValidator) security(config *configs.Config) error {
+ 		!config.Namespaces.Contains(configs.NEWNS) {
+ 		return fmt.Errorf("unable to restrict sys entries without a private MNT namespace")
+ 	}
+-	if config.ProcessLabel != "" && !selinux.GetEnabled() {
+-		return fmt.Errorf("selinux label is specified in config, but selinux is disabled or not supported")
+-	}
+ 
+ 	return nil
+ }
+diff --git a/utils_linux.go b/utils_linux.go
+index b05e7b60..ce50db14 100644
+--- a/utils_linux.go
++++ b/utils_linux.go
+@@ -17,7 +17,6 @@ import (
+ 	"github.com/opencontainers/runc/libcontainer/specconv"
+ 	"github.com/opencontainers/runc/libcontainer/utils"
+ 	"github.com/opencontainers/runtime-spec/specs-go"
+-	selinux "github.com/opencontainers/selinux/go-selinux"
+ 
+ 	"github.com/coreos/go-systemd/activation"
+ 	"github.com/pkg/errors"
+@@ -388,9 +387,6 @@ func validateProcessSpec(spec *specs.Process) error {
+ 	if len(spec.Args) == 0 {
+ 		return fmt.Errorf("args must not be empty")
+ 	}
+-	if spec.SelinuxLabel != "" && !selinux.GetEnabled() {
+-		return fmt.Errorf("selinux label is specified in config, but selinux is disabled or not supported")
+-	}
+ 	return nil
+ }
+ 
+-- 
+2.21.0
+


### PR DESCRIPTION
Do not error out if SELinux is specified but disabled
on the system.