### PR TITLE
sys-kernel/bootengine: Use only eth0 for DigitalOcean

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="94b8192c8f1c290a3dcf56f241be86d7c54d2ed5"  # flatcar-master
+	CROS_WORKON_COMMIT="01c5054be3f20e607c0717f48b06d79ebb74d907"  # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
See https://github.com/flatcar-linux/bootengine/pull/9

Note: Should be picked for `flatcar-master-alpha` and `flatcar-master-edge`