### PR TITLE
sys-apps/systemd: Enable timesyncd

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -383,6 +383,7 @@ multilib_src_install_all() {
 
 	systemd_enable_service multi-user.target systemd-networkd.service
 	systemd_enable_service multi-user.target systemd-resolved.service
+	systemd_enable_service sysinit.target systemd-timesyncd.service
 
 	# Do not enable random services if /etc was detected as empty!!!
 	rm "${ED}$(usex split-usr '' /usr)/lib/systemd/system-preset/90-systemd.preset" || die
@@ -484,7 +485,7 @@ pkg_postinst() {
 	# between OpenRC & systemd
 	migrate_locale
 
-	systemd_reenable systemd-networkd.service systemd-resolved.service
+	systemd_reenable systemd-networkd.service systemd-resolved.service systemd-timesyncd.service
 
 	if [[ ${ENABLED_UNITS[@]} ]]; then
 		systemctl --root="${ROOT:-/}" enable "${ENABLED_UNITS[@]}"


### PR DESCRIPTION
With the update to Systemd 243 timesyncd
is not enabled by default.
Force enabling it as we do with networkd
and resolved.