### PR TITLE
sys-apps/systemd: Set interface naming scheme to latest

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -292,8 +292,8 @@ multilib_src_configure() {
 		# Disable the "First Boot Wizard", it isn't very applicable to CoreOS
 		-Dfirstboot=false
 
-		# Preserve the v238 network interface naming scheme for compatibility.
-		-Ddefault-net-naming-scheme=v238
+		# Set latest network interface naming scheme for https://github.com/flatcar-linux/Flatcar/issues/36
+		-Ddefault-net-naming-scheme=latest
 
 		# unported options, still needed?
 		-Defi-cc="$(tc-getCC)"


### PR DESCRIPTION
When the initramfs gave a persistent name to
a network interface, renaming it via Name is
not working with the v238 naming scheme even
if NamePolicy is unset.
Switch to the newest network interface naming
scheme to resolve this issue.

https://github.com/flatcar-linux/Flatcar/issues/36

Note: Pick for alpha and edge.