### PR TITLE
.github: schedule daily Github actions for Go

### DIFF
--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+branch="go-${VERSION_NEW}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
+git checkout -B "${branch}" "github/${BASE_BRANCH}"
+
+versionOld=$(sed -n "s/^DIST go\(${GO_VERSION}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
+[[ "${VERSION_NEW}" = "${versionOld}" ]] && echo "already the latest Go, nothing to do" && exit
+
+pushd "dev-lang/go" >/dev/null || exit
+git mv $(ls -1 go-${versionOld}*.ebuild | sort -ruV | head -n1) "go-${VERSION_NEW}.ebuild"
+popd >/dev/null || exit
+
+( cd ../../..; exec cork enter -- ebuild "/mnt/host/source/src/third_party/coreos-overlay/dev-lang/go/go-${VERSION_NEW}.ebuild" manifest --force )
+
+# We can only create the actual commit in the actual source directory, not under the SDK.
+# So create a format-patch, and apply to the actual source.
+git add dev-lang/go/go-${VERSION_NEW}*
+git commit -a -m "dev-lang/go: Upgrade Go ${versionOld} to ${VERSION_NEW}"
+git format-patch -1 --stdout HEAD > "${branch}".patch
+popd || exit
+
+git config user.name 'Flatcar Buildbot'
+git config user.email 'buildbot@flatcar-linux.org'
+git reset --hard HEAD
+git fetch origin
+git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+git am ~/flatcar-sdk/src/third_party/coreos-overlay/"${branch}".patch
+
+echo ::set-output name=VERSION_OLD::"${versionOld}"

--- a/.github/workflows/go-releases-alpha.yml
+++ b/.github/workflows/go-releases-alpha.yml
@@ -1,0 +1,47 @@
+name: Get the latest Go release for Alpha
+on:
+  schedule:
+    - cron:  '15 7 * * *'
+
+jobs:
+  get-go-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Go release
+        id: fetch-latest-release
+        env:
+          GO_VERSION: 1.13
+        run: |
+          git clone https://github.com/golang/go
+          versionAlpha=$(git -C go tag | sed -n "/^go${GO_VERSION}.[0-9]*$/s/^go//p" | sort -ruV | head -1)
+          rm -rf go
+          echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
+          echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Alpha
+        id: apply-patch-alpha
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          GO_VERSION: 1.13
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+        run: .github/workflows/go-apply-patch.sh
+      - name: Create pull request for Alpha
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          branch: go-${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}-alpha
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Go in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          commit-message: Upgrade Go in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          body: Upgrade Go in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          labels: alpha

--- a/.github/workflows/go-releases-alpha.yml
+++ b/.github/workflows/go-releases-alpha.yml
@@ -15,8 +15,8 @@ jobs:
         env:
           GO_VERSION: 1.13
         run: |
-          git clone https://github.com/golang/go
-          versionAlpha=$(git -C go tag | sed -n "/^go${GO_VERSION}.[0-9]*$/s/^go//p" | sort -ruV | head -1)
+          git clone --depth=1 --no-checkout https://github.com/golang/go
+          versionAlpha=$(git -C go ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/go${GO_VERSION}.[0-9]*$/s/^refs\/tags\/go//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -1)
           rm -rf go
           echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
           echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha

--- a/.github/workflows/go-releases-edge.yml
+++ b/.github/workflows/go-releases-edge.yml
@@ -1,0 +1,47 @@
+name: Get the latest Go release for Edge
+on:
+  schedule:
+    - cron:  '20 7 * * *'
+
+jobs:
+  get-go-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Go release
+        id: fetch-latest-release
+        env:
+          GO_VERSION: 1.13
+        run: |
+          git clone https://github.com/golang/go
+          versionEdge=$(git -C go tag | sed -n "/^go${GO_VERSION}.[0-9]*$/s/^go//p" | sort -ruV | head -1)
+          rm -rf go
+          echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
+          echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Edge
+        id: apply-patch-edge
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          GO_VERSION: 1.13
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+        run: .github/workflows/go-apply-patch.sh
+      - name: Create pull request for Edge
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          branch: go-${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}-edge
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Go in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          commit-message: Upgrade Go in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          body: Upgrade Go in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          labels: edge

--- a/.github/workflows/go-releases-edge.yml
+++ b/.github/workflows/go-releases-edge.yml
@@ -15,8 +15,8 @@ jobs:
         env:
           GO_VERSION: 1.13
         run: |
-          git clone https://github.com/golang/go
-          versionEdge=$(git -C go tag | sed -n "/^go${GO_VERSION}.[0-9]*$/s/^go//p" | sort -ruV | head -1)
+          git clone --depth=1 --no-checkout https://github.com/golang/go
+          versionEdge=$(git -C go ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/go${GO_VERSION}.[0-9]*$/s/^refs\/tags\/go//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -1)
           rm -rf go
           echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
           echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge


### PR DESCRIPTION
Schedule daily Github actions for creating PRs for upstream Go releases, just like Kernel.

Replaces https://github.com/flatcar-linux/coreos-overlay/pull/186