### PR TITLE
.github: fix a commit message and exit code in Kernel workflows

### DIFF
--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -22,7 +22,7 @@ done
 # We can only create the actual commit in the actual source directory, not under the SDK.
 # So create a format-patch, and apply to the actual source.
 git add sys-kernel/coreos-*
-git commit -a -m "sys-kernel/coreos-sources: Upgrade Linux ${versionOld} to ${VERSION_NEW}"
+git commit -a -m "sys-kernel: Upgrade Linux ${versionOld} to ${VERSION_NEW}"
 git format-patch -1 --stdout HEAD > "${branch}".patch
 popd || exit
 

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -8,7 +8,7 @@ pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
 git checkout -B "${branch}" "github/${BASE_BRANCH}"
 
 versionOld=$(sed -n "s/^DIST patch-\(${KERNEL_VERSION}.[0-9]*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
-[[ "${VERSION_NEW}" = "$versionOld" ]] && echo "already the latest Kernel, nothing to do" && exit 1
+[[ "${VERSION_NEW}" = "$versionOld" ]] && echo "already the latest Kernel, nothing to do" && exit
 
 for pkg in sources modules kernel; do \
   pushd "sys-kernel/coreos-${pkg}" >/dev/null || exit; \


### PR DESCRIPTION
In the commit message, we should use a prefix `sys-kernel`, without `coreos-sources`.

Also make the entire Github actions not fail if the current release is already the latest Kernel.