### PR TITLE
coreos-base/oem-*: Fix coreos-cloudinit (cloud-config) variables

### DIFF
--- a/coreos-base/oem-cloudstack/files/flatcar-setup-environment
+++ b/coreos-base/oem-cloudstack/files/flatcar-setup-environment
@@ -14,8 +14,8 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-sed -i -e '/^FLATCAR_PUBLIC_IPV4=/d' \
-    -e '/^FLATCAR_PRIVATE_IPV4=/d' \
+sed -i -e '/^COREOS_PUBLIC_IPV4=/d' \
+    -e '/^COREOS_PRIVATE_IPV4=/d' \
     "${ENV}"
 
 . /usr/share/oem/bin/cloudstack-dhcp
@@ -26,7 +26,7 @@ METADATA_URL="http://${DHCP_SERVER}/latest/meta-data/"
 block-until-url "${METADATA_URL}"
 
 PUBLIC_IP=$(curl --fail -s "${METADATA_URL}public-ipv4")
-echo FLATCAR_PUBLIC_IPV4=${PUBLIC_IP} >> $ENV
+echo COREOS_PUBLIC_IPV4=${PUBLIC_IP} >> $ENV
 
 PRIVATE_IP=$(curl --fail -s "${METADATA_URL}local-ipv4")
-echo FLATCAR_PRIVATE_IPV4=${PRIVATE_IP} >> $ENV
+echo COREOS_PRIVATE_IPV4=${PRIVATE_IP} >> $ENV

--- a/coreos-base/oem-exoscale/files/flatcar-setup-environment
+++ b/coreos-base/oem-exoscale/files/flatcar-setup-environment
@@ -14,8 +14,8 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-sed -i -e '/^FLATCAR_PUBLIC_IPV4=/d' \
-    -e '/^FLATCAR_PRIVATE_IPV4=/d' \
+sed -i -e '/^COREOS_PUBLIC_IPV4=/d' \
+    -e '/^COREOS_PRIVATE_IPV4=/d' \
     "${ENV}"
 
 . /usr/share/oem/bin/exoscale-dhcp
@@ -26,7 +26,7 @@ METADATA_URL="http://${DHCP_SERVER}/latest/"
 block-until-url "${METADATA_URL}"
 
 PUBLIC_IP=$(curl --fail -s "${METADATA_URL}public-ipv4")
-echo FLATCAR_PUBLIC_IPV4=${PUBLIC_IP} >> $ENV
+echo COREOS_PUBLIC_IPV4=${PUBLIC_IP} >> $ENV
 
 PRIVATE_IP=$(curl --fail -s "${METADATA_URL}local-ipv4")
-echo FLATCAR_PRIVATE_IPV4=${PRIVATE_IP} >> $ENV
+echo COREOS_PRIVATE_IPV4=${PRIVATE_IP} >> $ENV

--- a/coreos-base/oem-interoute/files/flatcar-setup-environment
+++ b/coreos-base/oem-interoute/files/flatcar-setup-environment
@@ -16,8 +16,8 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Clean up values
-sed -i -e '/^FLATCAR_PUBLIC_IPV4=/d' \
-    -e '/^FLATCAR_PRIVATE_IPV4=/d' \
+sed -i -e '/^COREOS_PUBLIC_IPV4=/d' \
+    -e '/^COREOS_PRIVATE_IPV4=/d' \
     "${ENV}"
 
 sed -i -e '/^NIC_[0-9]*_IPV4=/d' \
@@ -46,10 +46,10 @@ METADATA_URL="http://${DHCP_SERVER}/latest/meta-data/"
 block-until-url "${METADATA_URL}"
 
 PUBLIC_IP=$(curl --fail -s "${METADATA_URL}public-ipv4")
-echo FLATCAR_PUBLIC_IPV4=${PUBLIC_IP} >> $ENV
+echo COREOS_PUBLIC_IPV4=${PUBLIC_IP} >> $ENV
 
 PRIVATE_IP=$(curl --fail -s "${METADATA_URL}local-ipv4")
-echo FLATCAR_PRIVATE_IPV4=${PRIVATE_IP} >> $ENV
+echo COREOS_PRIVATE_IPV4=${PRIVATE_IP} >> $ENV
 
 # Loop to export interoute style info into ENV
 count=1

--- a/coreos-base/oem-niftycloud/files/flatcar-setup-environment
+++ b/coreos-base/oem-niftycloud/files/flatcar-setup-environment
@@ -14,8 +14,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-sed -i -e '/^FLATCAR_PUBLIC_IPV4=/d' \
-    -e '/^FLATCAR_PRIVATE_IPV4=/d' \
+sed -i -e '/^COREOS_PUBLIC_IPV4=/d' \
+    -e '/^COREOS_PRIVATE_IPV4=/d' \
     "${ENV}"
 
 function get_ip () {
@@ -31,5 +31,5 @@ function get_ip () {
     echo $IP
 }
 
-echo FLATCAR_PUBLIC_IPV4=$(get_ip ens192) >> $ENV
-echo FLATCAR_PRIVATE_IPV4=$(get_ip ens224) >> $ENV
+echo COREOS_PUBLIC_IPV4=$(get_ip ens192) >> $ENV
+echo COREOS_PRIVATE_IPV4=$(get_ip ens224) >> $ENV

--- a/coreos-base/oem-rackspace/files/flatcar-setup-environment
+++ b/coreos-base/oem-rackspace/files/flatcar-setup-environment
@@ -13,8 +13,8 @@ if [ $? -ne 0 ]; then
         exit 1
 fi
 
-sed -i -e '/^FLATCAR_PUBLIC_IPV4=/d' \
-    -e '/^FLATCAR_PRIVATE_IPV4=/d' \
+sed -i -e '/^COREOS_PUBLIC_IPV4=/d' \
+    -e '/^COREOS_PRIVATE_IPV4=/d' \
     "${ENV}"
 
 # We spin loop until the nova-agent sets up the ip addresses
@@ -31,5 +31,5 @@ function get_ip () {
 	echo $IP	
 }
 
-echo FLATCAR_PUBLIC_IPV4=$(get_ip eth0) >> $ENV
-echo FLATCAR_PRIVATE_IPV4=$(get_ip eth1) >> $ENV
+echo COREOS_PUBLIC_IPV4=$(get_ip eth0) >> $ENV
+echo COREOS_PRIVATE_IPV4=$(get_ip eth1) >> $ENV

--- a/coreos-base/oem-vagrant/files/box/configure_networks.rb
+++ b/coreos-base/oem-vagrant/files/box/configure_networks.rb
@@ -16,8 +16,8 @@ BASE_CLOUD_CONFIG = <<EOF
 write_files:
   - path: /etc/environment
     content: |
-      FLATCAR_PUBLIC_IPV4=%s
-      FLATCAR_PRIVATE_IPV4=%s
+      COREOS_PUBLIC_IPV4=%s
+      COREOS_PRIVATE_IPV4=%s
 coreos:
     units:
 EOF

--- a/coreos-base/oem-vagrant/files/flatcar-setup-environment
+++ b/coreos-base/oem-vagrant/files/flatcar-setup-environment
@@ -11,12 +11,12 @@ now=$(date +%s)
 timeout=$(( now + 60 ))
 
 # just block until cloudinit updates environment 
-while ! grep -qs ^FLATCAR_PUBLIC_IPV4 "$ENV"; do
+while ! grep -qs ^COREOS_PUBLIC_IPV4 "$ENV"; do
     if [[ $timeout -lt $(date +%s) ]]; then
         echo "No network configuration provided by Vagrant!" >&2
         echo "Using localhost, for default public and private IPs" >&2
-        echo "FLATCAR_PUBLIC_IPV4=127.0.0.1" >> "$ENV"
-        echo "FLATCAR_PRIVATE_IPV4=127.0.0.1" >> "$ENV"
+        echo "COREOS_PUBLIC_IPV4=127.0.0.1" >> "$ENV"
+        echo "COREOS_PRIVATE_IPV4=127.0.0.1" >> "$ENV"
         exit
     fi
     sleep 0.1


### PR DESCRIPTION
The variables in /etc/environment are prefixed with COREOS_,
similar to how afterburn variables are prefixed with COREOS_.
They are not to be renamed.

Note: Pick for alpha and edge.