### PR TITLE
coreos-base/update_engine: Point to flatcar-master

### DIFF
--- a/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/coreos-base/update_engine/update_engine-9999.ebuild
@@ -9,7 +9,7 @@ AUTOTOOLS_AUTORECONF=1
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="ccdca5049cf7b65370369486ae8b822b6ce2a416" # flatcar-master
+	CROS_WORKON_COMMIT="efee1cb9223dbf017379d3644a265b3491a73c8a" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
Pulls in
https://github.com/flatcar-linux/update_engine/pull/2

Note: Pick for alpha and edge.