### PR TITLE
.github: schedule daily Github actions for Rust

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly SDK_OUTER_TOPDIR="${HOME}/flatcar-sdk"
+readonly SDK_OUTER_SRCDIR="${SDK_OUTER_TOPDIR}/src"
+readonly SDK_INNER_SRCDIR="/mnt/host/source/src"
+
+readonly BUILDBOT_USERNAME="Flatcar Buildbot"
+readonly BUILDBOT_USEREMAIL="buildbot@flatcar-linux.org"
+
+function enter() ( cd ../../..; exec cork enter -- $@ )
+
+# caller needs to set pass a parameter as a branch name to be created.
+function checkout_branches() {
+  TARGET_BRANCH=$1
+
+  [[ -z "${TARGET_BRANCH}" ]] && echo "No target branch specified. exit." && exit 1
+
+  git -C "${SDK_OUTER_SRCDIR}/scripts" checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+  git -C "${SDK_OUTER_SRCDIR}/third_party/portage-stable" checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+  git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" checkout -B "${TARGET_BRANCH}" "github/${BASE_BRANCH}"
+}
+
+function generate_patches() {
+  CATEGORY_NAME=$1
+  PKGNAME_SIMPLE=$2
+  PKGNAME_DESC=$3
+
+  pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
+
+  enter ebuild "${SDK_INNER_SRCDIR}/third_party/coreos-overlay/${CATEGORY_NAME}/${PKGNAME_SIMPLE}/${PKGNAME_SIMPLE}-${VERSION_NEW}.ebuild" manifest --force
+
+  # We can only create the actual commit in the actual source directory, not under the SDK.
+  # So create a format-patch, and apply to the actual source.
+  git add ${CATEGORY_NAME}/${PKGNAME_SIMPLE}
+  git commit -a -m "${CATEGORY_NAME}: Upgrade ${PKGNAME_DESC} ${VERSION_OLD} to ${VERSION_NEW}"
+
+  # Generate metadata after the main commit was done.
+  enter "${SDK_INNER_SRCDIR}/scripts/update_metadata" --commit coreos
+
+  # Create 2 patches, one for the main ebuilds, the other for metadata changes.
+  git format-patch -2 HEAD
+  popd || exit
+}
+
+function apply_patches() {
+  git config user.name "${BUILDBOT_USERNAME}"
+  git config user.email "${BUILDBOT_USEREMAIL}"
+  git reset --hard HEAD
+  git fetch origin
+  git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+  git am "${SDK_OUTER_SRCDIR}"/third_party/coreos-overlay/0*.patch
+}

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -2,13 +2,11 @@
 
 set -euo pipefail
 
-branch="docker-${VERSION_NEW}"
+. .github/workflows/common.sh
 
-git -C ~/flatcar-sdk/src/scripts checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
-git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+checkout_branches "docker-${VERSION_NEW}"
 
-pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
-git checkout -B "${branch}" "github/${BASE_BRANCH}"
+pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
 [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Docker, nothing to do" && exit
@@ -32,28 +30,10 @@ versionRunc=$(sed -n "s/^DIST docker-runc-\([0-9]*.[0-9]*.*\)\.tar.*/\1/p" app-e
 runcEbuildFile=$(ls -1 app-emulation/docker-runc/docker-runc-${versionRunc}*.ebuild | sort -ruV | head -n1)
 sed -i "s/github.com\/docker\/docker-ce\/blob\/v${VERSION_OLD}/github.com\/docker\/docker-ce\/blob\/v${VERSION_NEW}/g" ${runcEbuildFile}
 
-function enter() ( cd ../../..; exec cork enter -- $@ )
+popd >/dev/null || exit
 
-# Update manifest and regenerate metadata
-enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/app-emulation/docker/docker-${VERSION_NEW}.ebuild" manifest --force
+generate_patches app-emulation docker Docker
 
-# We can only create the actual commit in the actual source directory, not under the SDK.
-# So create a format-patch, and apply to the actual source.
-git add app-emulation/docker/docker-${VERSION_NEW}* app-torcx metadata
-git commit -a -m "app-emulation/docker: Upgrade Docker ${VERSION_OLD} to ${VERSION_NEW}"
-
-# Generate metadata after the main commit was done.
-enter /mnt/host/source/src/scripts/update_metadata --commit coreos
-
-# Create 2 patches, one for the main ebuilds, the other for metadata changes.
-git format-patch -2 HEAD
-popd || exit
-
-git config user.name 'Flatcar Buildbot'
-git config user.email 'buildbot@flatcar-linux.org'
-git reset --hard HEAD
-git fetch origin
-git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
-git am ~/flatcar-sdk/src/third_party/coreos-overlay/0*.patch
+apply_patches
 
 echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -10,11 +10,11 @@ git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}"
 pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
 git checkout -B "${branch}" "github/${BASE_BRANCH}"
 
-versionOld=$(sed -n "s/^DIST go\(${GO_VERSION}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
-[[ "${VERSION_NEW}" = "${versionOld}" ]] && echo "already the latest Go, nothing to do" && exit
+VERSION_OLD=$(sed -n "s/^DIST go\(${GO_VERSION}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
+[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Go, nothing to do" && exit
 
 pushd "dev-lang/go" >/dev/null || exit
-git mv $(ls -1 go-${versionOld}*.ebuild | sort -ruV | head -n1) "go-${VERSION_NEW}.ebuild"
+git mv $(ls -1 go-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "go-${VERSION_NEW}.ebuild"
 popd >/dev/null || exit
 
 function enter() ( cd ../../..; exec cork enter -- $@ )
@@ -24,7 +24,7 @@ enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/dev-lang/go/go-${V
 # We can only create the actual commit in the actual source directory, not under the SDK.
 # So create a format-patch, and apply to the actual source.
 git add dev-lang/go/go-${VERSION_NEW}* metadata
-git commit -a -m "dev-lang/go: Upgrade Go ${versionOld} to ${VERSION_NEW}"
+git commit -a -m "dev-lang/go: Upgrade Go ${VERSION_OLD} to ${VERSION_NEW}"
 
 # Generate metadata after the main commit was done.
 enter /mnt/host/source/src/scripts/update_metadata --commit coreos
@@ -40,4 +40,4 @@ git fetch origin
 git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
 git am ~/flatcar-sdk/src/third_party/coreos-overlay/0*.patch
 
-echo ::set-output name=VERSION_OLD::"${versionOld}"
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -2,42 +2,21 @@
 
 set -euo pipefail
 
-branch="go-${VERSION_NEW}"
+. .github/workflows/common.sh
 
-git -C ~/flatcar-sdk/src/scripts checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
-git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+checkout_branches "go-${VERSION_NEW}"
 
-pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
-git checkout -B "${branch}" "github/${BASE_BRANCH}"
+pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST go\(${GO_VERSION}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
 [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Go, nothing to do" && exit
 
-pushd "dev-lang/go" >/dev/null || exit
-git mv $(ls -1 go-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "go-${VERSION_NEW}.ebuild"
+git mv $(ls -1 dev-lang/go/go-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "dev-lang/go/go-${VERSION_NEW}.ebuild"
+
 popd >/dev/null || exit
 
-function enter() ( cd ../../..; exec cork enter -- $@ )
+generate_patches dev-lang go Go
 
-enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/dev-lang/go/go-${VERSION_NEW}.ebuild" manifest --force
-
-# We can only create the actual commit in the actual source directory, not under the SDK.
-# So create a format-patch, and apply to the actual source.
-git add dev-lang/go/go-${VERSION_NEW}* metadata
-git commit -a -m "dev-lang/go: Upgrade Go ${VERSION_OLD} to ${VERSION_NEW}"
-
-# Generate metadata after the main commit was done.
-enter /mnt/host/source/src/scripts/update_metadata --commit coreos
-
-# Create 2 patches, one for the main ebuilds, the other for metadata changes.
-git format-patch -2 HEAD
-popd || exit
-
-git config user.name 'Flatcar Buildbot'
-git config user.email 'buildbot@flatcar-linux.org'
-git reset --hard HEAD
-git fetch origin
-git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
-git am ~/flatcar-sdk/src/third_party/coreos-overlay/0*.patch
+apply_patches
 
 echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -2,13 +2,11 @@
 
 set -euo pipefail
 
-branch="rust-${VERSION_NEW}"
+. .github/workflows/common.sh
 
-git -C ~/flatcar-sdk/src/scripts checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
-git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+checkout_branches "rust-${VERSION_NEW}"
 
-pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
-git checkout -B "${branch}" "github/${BASE_BRANCH}"
+pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 updateNeeded=1
 VERSION_OLD=$(sed -n "s/^DIST rustc-\(1.[0-9]*.[0-9]*\).*/\1/p" dev-lang/rust/Manifest | sort -ruV | head -n1)
@@ -18,28 +16,11 @@ pushd "dev-lang/rust" >/dev/null || exit
 git mv $(ls -1 rust-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "rust-${VERSION_NEW}.ebuild"
 popd >/dev/null || exit
 
-function enter() ( cd ../../.. ; exec cork enter -- "$@" )
+popd >/dev/null || exit
 
-enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/dev-lang/rust/rust-${VERSION_NEW}.ebuild" manifest --force
+generate_patches dev-lang rust Rust
 
-# We can only create the actual commit in the actual source directory, not under the SDK.
-# So create a format-patch, and apply to the actual source.
-git add dev-lang/rust/{rust-${VERSION_NEW},Manifest}*
-git commit -a -m "dev-lang/rust: Upgrade Rust ${VERSION_OLD} to ${VERSION_NEW}"
-
-# Generate metadata after the main commit was done.
-enter /mnt/host/source/src/scripts/update_metadata --commit coreos
-
-# Create 2 patches, one for the main ebuilds, the other for metadata changes.
-git format-patch -2 HEAD
-popd || exit
-
-git config user.name 'Flatcar Buildbot'
-git config user.email 'buildbot@flatcar-linux.org'
-git reset --hard HEAD
-git fetch origin
-git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
-git am ~/flatcar-sdk/src/third_party/coreos-overlay/0*.patch
+apply_patches
 
 echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
 echo ::set-output name=UPDATE_NEEDED::"${updateNeeded}"

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+branch="rust-${VERSION_NEW}"
+
+git -C ~/flatcar-sdk/src/scripts checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
+git checkout -B "${branch}" "github/${BASE_BRANCH}"
+
+updateNeeded=1
+VERSION_OLD=$(sed -n "s/^DIST rustc-\(1.[0-9]*.[0-9]*\).*/\1/p" dev-lang/rust/Manifest | sort -ruV | head -n1)
+[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Rust, nothing to do" && updateNeeded=0 && exit
+
+pushd "dev-lang/rust" >/dev/null || exit
+git mv $(ls -1 rust-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "rust-${VERSION_NEW}.ebuild"
+popd >/dev/null || exit
+
+function enter() ( cd ../../.. ; exec cork enter -- "$@" )
+
+enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/dev-lang/rust/rust-${VERSION_NEW}.ebuild" manifest --force
+
+# We can only create the actual commit in the actual source directory, not under the SDK.
+# So create a format-patch, and apply to the actual source.
+git add dev-lang/rust/{rust-${VERSION_NEW},Manifest}*
+git commit -a -m "dev-lang/rust: Upgrade Rust ${VERSION_OLD} to ${VERSION_NEW}"
+
+# Generate metadata after the main commit was done.
+enter /mnt/host/source/src/scripts/update_metadata --commit coreos
+
+# Create 2 patches, one for the main ebuilds, the other for metadata changes.
+git format-patch -2 HEAD
+popd || exit
+
+git config user.name 'Flatcar Buildbot'
+git config user.email 'buildbot@flatcar-linux.org'
+git reset --hard HEAD
+git fetch origin
+git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+git am ~/flatcar-sdk/src/third_party/coreos-overlay/0*.patch
+
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
+echo ::set-output name=UPDATE_NEEDED::"${updateNeeded}"

--- a/.github/workflows/rust-release-alpha.yml
+++ b/.github/workflows/rust-release-alpha.yml
@@ -1,0 +1,52 @@
+name: Get the latest Rust release for Alpha
+on:
+  schedule:
+    - cron:  '20 7 * * *'
+
+jobs:
+  get-rust-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Rust release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/rust-lang/rust
+          versionAlpha=$(git -C rust ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/1.[0-9]*.[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
+          rm -rf rust
+          echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
+          echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Alpha
+        id: apply-patch-alpha
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+        run: .github/workflows/rust-apply-patch.sh
+      - name: Create pull request for Alpha
+        uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-alpha.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          branch: rust-${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}-alpha
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Rust in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          commit-message: Upgrade Rust in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          body: Upgrade Rust in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          labels: alpha
+      - name: Send repository dispatch to portage-stable
+        uses: peter-evans/repository-dispatch@v1.0.0
+        if: steps.apply-patch-alpha.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.FLATCAR_PORTAGE_STABLE_ACCESS_TOKEN }}
+          repository: flatcar-linux/portage-stable
+          event-type: cargo-pull-request-alpha

--- a/.github/workflows/rust-release-edge.yml
+++ b/.github/workflows/rust-release-edge.yml
@@ -1,0 +1,52 @@
+name: Get the latest Rust release for Edge
+on:
+  schedule:
+    - cron:  '25 7 * * *'
+
+jobs:
+  get-rust-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Rust release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/rust-lang/rust
+          versionEdge=$(git -C rust ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/1.[0-9]*.[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
+          rm -rf rust
+          echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
+          echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Edge
+        id: apply-patch-edge
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+        run: .github/workflows/rust-apply-patch.sh
+      - name: Create pull request for Edge
+        uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-edge.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          branch: rust-${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}-edge
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Rust in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          commit-message: Upgrade Rust in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          body: Upgrade Rust in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          labels: edge
+      - name: Send repository dispatch to portage-stable
+        uses: peter-evans/repository-dispatch@v1.0.0
+        if: steps.apply-patch-edge.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.FLATCAR_PORTAGE_STABLE_ACCESS_TOKEN }}
+          repository: flatcar-linux/portage-stable
+          event-type: cargo-pull-request-edge


### PR DESCRIPTION
Schedule daily Github actions for creating PRs for upstream Rust releases.

The Github workflow will create pull request for `dev-lang/rust` in `coreos-overlay`. At the same time, it will send a repository dispatch event to `flatcar-linux/portage-stable`, to update also `virtual/cargo`. We need to send different event types to distinguish alpha from edge.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/28, https://github.com/flatcar-linux/portage-stable/pull/44, https://github.com/flatcar-linux/portage-stable/pull/45, and https://github.com/flatcar-linux/coreos-overlay/pull/221.