### PR TITLE
.github: set up coreos profiles after setting up SDK

### DIFF
--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -17,8 +17,31 @@ mkdir -p ~/flatcar-sdk
 pushd ~/flatcar-sdk || exit
 cork create || true
 
+sudo tee "./chroot/etc/portage/repos.conf/coreos.conf" <<EOF
+[DEFAULT]
+main-repo = portage-stable
+
+[gentoo]
+disabled = true
+
+[coreos]
+location = /mnt/host/source/src/third_party/coreos-overlay
+
+[portage-stable]
+location = /mnt/host/source/src/third_party/portage-stable
+EOF
+
 # /var under the chroot has to be writable by the runner user
 sudo chown -R runner:docker ~/flatcar-sdk/chroot/var
+
+function enter() ( exec cork enter -- $@ )
+
+# To be able to generate metadata, we need to configure a profile
+# /etc/portage/make.profile, a symlink pointing to the SDK profile.
+enter sudo eselect profile set --force "coreos:coreos/amd64/sdk"
+
+# make edb directory group-writable to run egencache
+enter sudo chmod g+w /var/cache/edb
 
 git -C src/third_party/coreos-overlay reset --hard github/flatcar-master
 git -C src/third_party/coreos-overlay config user.name 'Flatcar Buildbot'


### PR DESCRIPTION
We need to set up coreos profiles under `/etc/portage/repos.conf`, to be able to run any package-related actions like `emerge` or `egencache`.

Also change permissions for directories, so portage actions could write files.