### PR TITLE
.github: schedule daily Github actions for Docker

### DIFF
--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+
+branch="docker-${VERSION_NEW}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
+git checkout -B "${branch}" "github/${BASE_BRANCH}"
+
+VERSION_OLD=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
+[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Docker, nothing to do" && exit
+
+# we need to update not only the main ebuild file, but also its DOCKER_GITCOMMIT,
+# which needs to point to COMMIT_HASH that matches with $VERSION_NEW from upstream docker-ce.
+dockerEbuildOldSymlink=$(ls -1 app-emulation/docker/docker-${VERSION_OLD}*.ebuild | sort -ruV | head -n1)
+dockerEbuildNewSymlink="app-emulation/docker/docker-${VERSION_NEW}.ebuild"
+dockerEbuildMain="app-emulation/docker/docker-9999.ebuild"
+git mv ${dockerEbuildOldSymlink} ${dockerEbuildNewSymlink}
+sed -i "s/DOCKER_GITCOMMIT=\"\(.*\)\"/DOCKER_GITCOMMIT=\"${COMMIT_HASH}\"/g" ${dockerEbuildMain}
+sed -i "s/v${VERSION_OLD}/v${VERSION_NEW}/g" ${dockerEbuildMain}
+
+# torcx ebuild file has a docker version with only major and minor versions, like 19.03.
+versionTorcx=${VERSION_OLD%.*}
+torcxEbuildFile=$(ls -1 app-torcx/docker/docker-${versionTorcx}*.ebuild | sort -ruV | head -n1)
+sed -i "s/docker-${VERSION_OLD}/docker-${VERSION_NEW}/g" ${torcxEbuildFile}
+
+# update also docker versions used by the current docker-runc ebuild file.
+versionRunc=$(sed -n "s/^DIST docker-runc-\([0-9]*.[0-9]*.*\)\.tar.*/\1/p" app-emulation/docker-runc/Manifest | sort -ruV | head -n1)
+runcEbuildFile=$(ls -1 app-emulation/docker-runc/docker-runc-${versionRunc}*.ebuild | sort -ruV | head -n1)
+sed -i "s/github.com\/docker\/docker-ce\/blob\/v${VERSION_OLD}/github.com\/docker\/docker-ce\/blob\/v${VERSION_NEW}/g" ${runcEbuildFile}
+
+function enter() ( cd ../../..; exec cork enter -- $@ )
+
+# Update manifest and regenerate metadata
+enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/app-emulation/docker/docker-${VERSION_NEW}.ebuild" manifest --force
+
+# We can only create the actual commit in the actual source directory, not under the SDK.
+# So create a format-patch, and apply to the actual source.
+git add app-emulation/docker/docker-${VERSION_NEW}* app-torcx metadata
+git commit -a -m "app-emulation/docker: Upgrade Docker ${VERSION_OLD} to ${VERSION_NEW}"
+
+# Generate metadata after the main commit was done.
+enter /mnt/host/source/src/scripts/update_metadata --commit coreos
+
+# Create 2 patches, one for the main ebuilds, the other for metadata changes.
+git format-patch -2 HEAD
+popd || exit
+
+git config user.name 'Flatcar Buildbot'
+git config user.email 'buildbot@flatcar-linux.org'
+git reset --hard HEAD
+git fetch origin
+git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+git am ~/flatcar-sdk/src/third_party/coreos-overlay/0*.patch
+
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"

--- a/.github/workflows/docker-releases-alpha.yml
+++ b/.github/workflows/docker-releases-alpha.yml
@@ -1,0 +1,47 @@
+name: Get the latest Docker release for Alpha
+on:
+  schedule:
+    - cron:  '35 7 * * *'
+
+jobs:
+  get-docker-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Docker release
+        id: fetch-latest-release
+        run: |
+          git clone https://github.com/docker/docker-ce docker
+          versionAlpha=$(git -C docker ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
+          commitAlpha=$(git -C docker rev-parse --short=7 v${versionAlpha})
+          rm -rf docker
+          echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
+          echo ::set-output name=COMMIT_ALPHA::$(echo ${commitAlpha})
+          echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Alpha
+        id: apply-patch-alpha
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_ALPHA }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+        run: .github/workflows/docker-apply-patch.sh
+      - name: Create pull request for Alpha
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          branch: docker-${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}-alpha
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Docker in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          commit-message: Upgrade Docker in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          body: Upgrade Docker in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          labels: alpha

--- a/.github/workflows/docker-releases-edge.yml
+++ b/.github/workflows/docker-releases-edge.yml
@@ -1,0 +1,47 @@
+name: Get the latest Docker release for Edge
+on:
+  schedule:
+    - cron:  '40 7 * * *'
+
+jobs:
+  get-docker-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Docker release
+        id: fetch-latest-release
+        run: |
+          git clone https://github.com/docker/docker-ce docker
+          versionEdge=$(git -C docker ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
+          commitEdge=$(git -C docker rev-parse --short=7 v${versionEdge})
+          rm -rf docker
+          echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
+          echo ::set-output name=COMMIT_EDGE::$(echo ${commitEdge})
+          echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Edge
+        id: apply-patch-edge
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_EDGE }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+        run: .github/workflows/docker-apply-patch.sh
+      - name: Create pull request for Edge
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          branch: docker-${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}-edge
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Docker in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          commit-message: Upgrade Docker in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          body: Upgrade Docker in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          labels: edge


### PR DESCRIPTION
Schedule daily Github actions to get upstream Docker releases, for Alpha and Edge.

We need to change more files, as Docker version is used by `torcx` as well as `docker-runc`.

Should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/221