### PR TITLE
.github: schedule daily Github actions for runc

### DIFF
--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+branch="runc-${VERSION_NEW}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
+git checkout -B "${branch}" "github/${BASE_BRANCH}"
+
+VERSION_OLD=$(sed -n "s/^DIST docker-runc-\([0-9]*.[0-9]*.*\)\.tar.*/\1/p" app-emulation/docker-runc/Manifest | sort -ruV | head -n1 | tr '-' '_')
+[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Runc, nothing to do" && exit
+
+runcEbuildOld=$(ls -1 app-emulation/docker-runc/docker-runc-${VERSION_OLD}*.ebuild | sort -ruV | head -n1)
+runcEbuildNew="app-emulation/docker-runc/docker-runc-${VERSION_NEW}.ebuild"
+git mv ${runcEbuildOld} ${runcEbuildNew}
+sed -i "s/${VERSION_OLD}/${VERSION_NEW}/g" ${runcEbuildNew}
+
+# update also runc versions used by docker and containerd
+sed -i "s/docker-runc-${VERSION_OLD}/docker-runc-${VERSION_NEW}/g" app-emulation/docker/docker-9999.ebuild
+sed -i "s/docker-runc-${VERSION_OLD}/docker-runc-${VERSION_NEW}/g" app-emulation/containerd/containerd-9999.ebuild
+
+dockerVersion=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
+
+# torcx ebuild file has a docker version with only major and minor versions, like 19.03.
+versionTorcx=${dockerVersion%.*}
+torcxEbuildFile=$(ls -1 app-torcx/docker/docker-${versionTorcx}*.ebuild | sort -ruV | head -n1)
+sed -i "s/docker-runc-${VERSION_OLD}/docker-runc-${VERSION_NEW}/g" ${torcxEbuildFile}
+
+function enter() ( cd ../../..; exec cork enter -- $@ )
+
+# Update manifest and regenerate metadata
+enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/app-emulation/docker-runc/docker-runc-${VERSION_NEW}.ebuild" manifest --force
+
+# We can only create the actual commit in the actual source directory, not under the SDK.
+# So create a format-patch, and apply to the actual source.
+git add app-emulation/docker-runc/docker-runc-${VERSION_NEW}* app-torcx metadata
+git commit -a -m "app-emulation/docker-runc: Upgrade Runc ${VERSION_OLD} to ${VERSION_NEW}"
+
+# Generate metadata after the main commit was done.
+enter /mnt/host/source/src/scripts/update_metadata --commit coreos
+
+# Create 2 patches, one for the main ebuilds, the other for metadata changes.
+git format-patch -2 HEAD
+popd || exit
+
+git config user.name 'Flatcar Buildbot'
+git config user.email 'buildbot@flatcar-linux.org'
+git reset --hard HEAD
+git fetch origin
+git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+git am ~/flatcar-sdk/src/third_party/coreos-overlay/0*.patch
+
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"

--- a/.github/workflows/runc-releases-alpha.yml
+++ b/.github/workflows/runc-releases-alpha.yml
@@ -1,0 +1,47 @@
+name: Get the latest Runc release for Alpha
+on:
+  schedule:
+    - cron:  '50 7 * * *'
+
+jobs:
+  get-runc-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Runc release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/opencontainers/runc
+          # Get the newest runc version, including official releases and rc versions.
+          # We need some sed tweaks like adding underscore, sort, and trim the underscore again,
+          # so that sort -V can give the newest version including non-rc versions.
+          versionAlpha=$(git -C runc ls-remote --tags origin | cut -f2 | sed '/-/!{s/$/_/}' | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*/s/^refs\/tags\/v//p" |grep -v '\{\}$' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
+          rm -rf runc
+          echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
+          echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Alpha
+        id: apply-patch-alpha
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+        run: .github/workflows/runc-apply-patch.sh
+      - name: Create pull request for Alpha
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          branch: runc-${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}-alpha
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Runc in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          commit-message: Upgrade Runc in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          body: Upgrade Runc in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          labels: alpha

--- a/.github/workflows/runc-releases-edge.yml
+++ b/.github/workflows/runc-releases-edge.yml
@@ -1,0 +1,47 @@
+name: Get the latest Runc release for Edge
+on:
+  schedule:
+    - cron:  '55 7 * * *'
+
+jobs:
+  get-runc-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Runc release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/opencontainers/runc
+          # Get the newest runc version, including official releases and rc versions.
+          # We need some sed tweaks like adding underscore, sort, and trim the underscore again,
+          # so that sort -V can give the newest version including non-rc versions.
+          versionEdge=$(git -C runc ls-remote --tags origin | cut -f2 | sed '/-/!{s/$/_/}' | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*/s/^refs\/tags\/v//p" |grep -v '\{\}$' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
+          rm -rf runc
+          echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
+          echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Edge
+        id: apply-patch-edge
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+        run: .github/workflows/runc-apply-patch.sh
+      - name: Create pull request for Edge
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          branch: runc-${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}-edge
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Runc in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          commit-message: Upgrade Runc in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          body: Upgrade Runc in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          labels: edge


### PR DESCRIPTION
Schedule daily Github actions for upstream runc releases, just like Docker.

In this case, we also need to update multiple repos like `app-emulation/docker`, `app-emulation/containerd`, `app-torcx/docker`, etc.

Depends on https://github.com/flatcar-linux/coreos-overlay/pull/221