### PR TITLE
coreos-base/oem-packet: Fix TTY for ARM64

### DIFF
--- a/coreos-base/oem-packet/files/grub.cfg
+++ b/coreos-base/oem-packet/files/grub.cfg
@@ -3,7 +3,8 @@
 set oem_id="packet"
 set linux_append="flatcar.autologin"
 
+set linux_console="console=tty0 console=ttyS1,115200n8"
+
 if [ "$grub_cpu" = i386 ]; then
     set gfxpayload="1024x768x8,1024x768"
-    set linux_console="console=tty0 console=ttyS1,115200n8"
 fi


### PR DESCRIPTION
The default for arm64 is ttyAMA0 but the
c2.large.arm needs ttyS1.

Note: Pick for alpha and edge.