### PR TITLE
profiles: build tracepath in iputils

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -13,7 +13,7 @@ dev-util/perf		tui -doc
 dev-vcs/git		webdav curl bash-completion
 # We don't want any driver/hw rendering on the host
 net-misc/curl		kerberos threads
-net-misc/iputils	arping traceroute
+net-misc/iputils	arping tracepath traceroute
 sys-devel/gettext	-git
 app-emulation/qemu	aio caps curl jpeg ncurses png python threads uuid vhost-net virtfs vnc qemu_softmmu_targets_x86_64 qemu_softmmu_targets_aarch64
 


### PR DESCRIPTION
Enable a USE flag `tracepath` for iputils to get the `/usr/sbin/tracepath` binary file included in Flatcar images.

Note, the `tracepath` flag is not the same as the existing `traceroute` flag, which enables only `tracerout6`.