### PR TITLE
.github: schedule daily Github actions for Kernel in beta, stable

### DIFF
--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -14,7 +14,12 @@ pushd "dev-lang/go" >/dev/null || exit
 git mv $(ls -1 go-${versionOld}*.ebuild | sort -ruV | head -n1) "go-${VERSION_NEW}.ebuild"
 popd >/dev/null || exit
 
-( cd ../../..; exec cork enter -- ebuild "/mnt/host/source/src/third_party/coreos-overlay/dev-lang/go/go-${VERSION_NEW}.ebuild" manifest --force )
+function enter() ( cd ../../..; exec cork enter -- $@ )
+
+enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/dev-lang/go/go-${VERSION_NEW}.ebuild" manifest --force
+
+# Generate metadata after the main commit was done.
+enter /mnt/host/source/src/scripts/update_metadata --commit coreos
 
 # We can only create the actual commit in the actual source directory, not under the SDK.
 # So create a format-patch, and apply to the actual source.

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -17,7 +17,12 @@ for pkg in sources modules kernel; do \
   popd >/dev/null || exit; \
 done
 
-( cd ../../..; exec cork enter -- ebuild "/mnt/host/source/src/third_party/coreos-overlay/sys-kernel/coreos-sources/coreos-sources-${VERSION_NEW}.ebuild" manifest --force )
+function enter() ( cd ../../..; exec cork enter -- $@ )
+
+enter ebuild "/mnt/host/source/src/third_party/coreos-overlay/sys-kernel/coreos-sources/coreos-sources-${VERSION_NEW}.ebuild" manifest --force
+
+# Generate metadata after the main commit was done.
+enter /mnt/host/source/src/scripts/update_metadata --commit coreos
 
 # We can only create the actual commit in the actual source directory, not under the SDK.
 # So create a format-patch, and apply to the actual source.

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -1,0 +1,47 @@
+name: Get the latest Kernel release for Beta
+on:
+  schedule:
+    - cron:  '50 6 * * *'
+
+jobs:
+  get-kernel-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Kernel release
+        id: fetch-latest-release
+        env:
+          KV_BETA: 4.19
+        run: |
+          git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
+          versionBeta=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_BETA}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
+          rm -rf linux
+          echo ::set-output name=VERSION_BETA::$(echo ${versionBeta})
+          echo ::set-output name=BASE_BRANCH_BETA::flatcar-master-beta
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Beta
+        id: apply-patch-beta
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_BETA }}
+          KERNEL_VERSION: 4.19
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_BETA }}
+        run: .github/workflows/kernel-apply-patch.sh
+      - name: Create pull request for Beta
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_BETA }}
+          branch: linux-${{ steps.fetch-latest-release.outputs.VERSION_BETA }}-beta
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Linux Kernel in Beta from ${{ steps.apply-patch-beta.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_BETA }}
+          commit-message: Upgrade Linux Kernel in Beta from ${{ steps.apply-patch-beta.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_BETA }}
+          body: Upgrade Linux Kernel in Beta from ${{ steps.apply-patch-beta.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_BETA }}
+          labels: beta

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -1,0 +1,47 @@
+name: Get the latest Kernel release for Stable
+on:
+  schedule:
+    - cron:  '40 6 * * *'
+
+jobs:
+  get-kernel-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Kernel release
+        id: fetch-latest-release
+        env:
+          KV_STABLE: 4.19
+        run: |
+          git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
+          versionStable=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_STABLE}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
+          rm -rf linux
+          echo ::set-output name=VERSION_STABLE::$(echo ${versionStable})
+          echo ::set-output name=BASE_BRANCH_STABLE::flatcar-master
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Stable
+        id: apply-patch-stable
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_STABLE }}
+          KERNEL_VERSION: 4.19
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_STABLE }}
+        run: .github/workflows/kernel-apply-patch.sh
+      - name: Create pull request for Stable
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_STABLE }}
+          branch: linux-${{ steps.fetch-latest-release.outputs.VERSION_STABLE }}-stable
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Linux Kernel in Stable from ${{ steps.apply-patch-stable.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_STABLE }}
+          commit-message: Upgrade Linux Kernel in Stable from ${{ steps.apply-patch-stable.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_STABLE }}
+          body: Upgrade Linux Kernel in Stable from ${{ steps.apply-patch-stable.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_STABLE }}
+          labels: stable


### PR DESCRIPTION
Check for upstream Kernel releases once in a day, for Beta and Stable,
just like it has been done for Alpha and Edge.