### PR TITLE
.github: update Kernel to 5.6 for Edge

### DIFF
--- a/.github/workflows/kernel-releases-edge.yml
+++ b/.github/workflows/kernel-releases-edge.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Fetch latest Kernel release
         id: fetch-latest-release
         env:
-          KV_EDGE: 5.5
+          KV_EDGE: 5.6
         run: |
           git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
           versionEdge=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_EDGE}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)
@@ -29,7 +29,7 @@ jobs:
         id: apply-patch-edge
         env:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
-          KERNEL_VERSION: 5.5
+          KERNEL_VERSION: 5.6
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
         run: .github/workflows/kernel-apply-patch.sh


### PR DESCRIPTION
Upgrade the base Kernel version from 5.5 to 5.6 for the Edge channel.
