### PR TITLE
profiles: accept keywords ~arm64 for openssh 8.1 for alpha

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -70,3 +70,5 @@ dev-util/checkbashisms
 
 =sys-libs/libsepol-2.4 **
 =sys-libs/libselinux-2.4 **
+
+=net-misc/openssh-8.1_p1-r3 ~arm64


### PR DESCRIPTION
Now that openssh was updated to 8.1, we need to make openssh accept keywords `~arm64` for it, to avoid build failures.

## How to use

```
emerge-arm64-usr net-misc/openssh
```