### PR TITLE
profiles: accept keywords ~arm64 for openssh 8.1 for edge

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -81,3 +81,5 @@ dev-util/checkbashisms
 
 =dev-util/dwarves-1.16 ~amd64
 =dev-libs/elfutils-0.178 ~amd64
+
+=net-misc/openssh-8.1_p1-r3 ~arm64


### PR DESCRIPTION
Now that openssh was updated to 8.1, we need to make openssh accept keywords `~arm64` for it, to avoid build failures.

## How to use

```
emerge-arm64-usr net-misc/openssh
```