### PR TITLE
.github: check out correct base branches before applying patches

### DIFF
--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 
 branch="docker-${VERSION_NEW}"
 
-pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
+git -C ~/flatcar-sdk/src/scripts checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
 git checkout -B "${branch}" "github/${BASE_BRANCH}"
 
 VERSION_OLD=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 
 branch="go-${VERSION_NEW}"
 
-pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
+git -C ~/flatcar-sdk/src/scripts checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
 git checkout -B "${branch}" "github/${BASE_BRANCH}"
 
 versionOld=$(sed -n "s/^DIST go\(${GO_VERSION}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 
 branch="linux-${VERSION_NEW}"
 
-pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
+git -C ~/flatcar-sdk/src/scripts checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
 git checkout -B "${branch}" "github/${BASE_BRANCH}"
 
 versionOld=$(sed -n "s/^DIST patch-\(${KERNEL_VERSION}.[0-9]*\).*/\1/p" sys-kernel/coreos-sources/Manifest)

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 
 branch="runc-${VERSION_NEW}"
 
-pushd ~/flatcar-sdk/src/third_party/coreos-overlay || exit
+git -C ~/flatcar-sdk/src/scripts checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+git -C ~/flatcar-sdk/src/third_party/portage-stable checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+
+pushd ~/flatcar-sdk/src/third_party/coreos-overlay >/dev/null || exit
 git checkout -B "${branch}" "github/${BASE_BRANCH}"
 
 # Get the original runc version, including official releases and rc versions.


### PR DESCRIPTION
Before starting to apply patches inside `coreos-overlay`, we need to check out base branches, also for `scripts` and `portage-stable`.

Otherwise, in case of Beta, Alpha, or Edge, `ebuild` commands could fail due to mismatch of ebuild files across multiple repos like `coreos-overlay` and `portage-stable`.
