### PR TITLE
.github: use correct make.conf when setting up Flatcar SDK

### DIFF
--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -17,6 +17,14 @@ mkdir -p ~/flatcar-sdk
 pushd ~/flatcar-sdk || exit
 cork create || true
 
+sudo tee "./chroot/etc/portage/make.conf" <<EOF
+PORTDIR="/mnt/host/source/src/third_party/portage-stable"
+PORTDIR_OVERLAY="/mnt/host/source/src/third_party/coreos-overlay"
+DISTDIR="/mnt/host/source/.cache/distfiles"
+PKGDIR="/var/lib/portage/pkgs"
+PORT_LOGDIR="/var/log/portage"
+EOF
+
 sudo tee "./chroot/etc/portage/repos.conf/coreos.conf" <<EOF
 [DEFAULT]
 main-repo = portage-stable


### PR DESCRIPTION
When setting up a Flatcar SDK from scratch, we need to also set up correct configs in `/etc/portage/make.conf`.

For example we need to set `PORTDIR=/mnt/host/source/src/third_party/portage-stable` instead of the default Gentoo configs like `PORTDIR=/var/gentoo/repos/gentoo`.

Otherwise `update_metadata` will fail in some cases, because portage cannot find the correct location of portage-stable.

## Testing done

Tested via a testing repo. It works.