### PR TITLE
coreos-base/oem*: Fix bug report URL

### DIFF
--- a/coreos-base/oem-azure/files/oem-release
+++ b/coreos-base/oem-azure/files/oem-release
@@ -2,4 +2,4 @@ ID=azure
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Microsoft Azure"
 HOME_URL="https://azure.microsoft.com/"
-BUG_REPORT_URL="https://issues.coreos.com"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-digitalocean/files/oem-release
+++ b/coreos-base/oem-digitalocean/files/oem-release
@@ -2,4 +2,4 @@ ID=digitalocean
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="DigitalOcean"
 HOME_URL="https://www.digitalocean.com/"
-BUG_REPORT_URL="https://issues.coreos.com"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-ec2-compat/files/oem-release
+++ b/coreos-base/oem-ec2-compat/files/oem-release
@@ -2,4 +2,4 @@ ID=@@OEM_ID@@
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="@@OEM_NAME@@"
 HOME_URL="@@OEM_HOME_URL@@"
-BUG_REPORT_URL="https://issues.coreos.com"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-gce/files/oem-release
+++ b/coreos-base/oem-gce/files/oem-release
@@ -2,4 +2,4 @@ ID=gce
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Google Compute Engine"
 HOME_URL="https://cloud.google.com/products/compute-engine/"
-BUG_REPORT_URL="https://issues.coreos.com"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-hyperv/files/oem-release
+++ b/coreos-base/oem-hyperv/files/oem-release
@@ -1,4 +1,4 @@
 ID=hyperv
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Microsoft Hyper-V"
-BUG_REPORT_URL="https://issues.coreos.com"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-packet/files/oem-release
+++ b/coreos-base/oem-packet/files/oem-release
@@ -2,4 +2,4 @@ ID=packet
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Packet"
 HOME_URL="https://packet.net"
-BUG_REPORT_URL="https://issues.coreos.com"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-virtualbox/files/oem-release
+++ b/coreos-base/oem-virtualbox/files/oem-release
@@ -1,4 +1,4 @@
 ID=virtualbox
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Oracle VirtualBox"
-BUG_REPORT_URL="https://issues.coreos.com"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-vmware/files/oem-release
+++ b/coreos-base/oem-vmware/files/oem-release
@@ -2,4 +2,4 @@ ID=vmware
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="VMware"
 HOME_URL="https://www.vmware.com/"
-BUG_REPORT_URL="https://issues.coreos.com"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"


### PR DESCRIPTION
The bug report URL was pointing to the CoreOS bug tracker.
Change it to Flatcar's bug tracker URL.

# How to use

- Checkout this branch for coreos-overlay in your SDK
- Build the package and image if not done yet
- Generate the VM images with the printed command but add `--format OEMNAME` to generate a image with the OEM partition
- Mount or boot it and check the content of `/usr/share/oem/oem-release`

# Testing done

None

**Note:** Should be cherry-picked for `flatcar-master-(alpha|beta|edge)`.