### PR TITLE
app-admin/mayday: Point to flatcar-master

### DIFF
--- a/app-admin/mayday/mayday-9999.ebuild
+++ b/app-admin/mayday/mayday-9999.ebuild
@@ -11,7 +11,7 @@ inherit coreos-go cros-workon
 if [[ "${PV}" == 9999 ]]; then
     KEYWORDS="~amd64 ~arm64"
 else
-    CROS_WORKON_COMMIT="b2b1b3cb6beed130454b3fb04b45a020997a9edd" # flatcar-master
+    CROS_WORKON_COMMIT="73e4d2f5803362667677226f4e2e538217b38d75" # flatcar-master
     KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/mayday/pull/8
to include "coredumpctl list" in the tar ball.

Note: Pick for alpha/beta/edge.