### PR TITLE
Adapt the sed command to the new file contents

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -422,8 +422,8 @@ multilib_src_install_all() {
 	# Do not ship distro-specific files (nsswitch.conf pam.d)
 	rm -rf "${ED}"/usr/share/factory
 	sed -i "${ED}"/usr/lib/tmpfiles.d/etc.conf \
-		-e '/^C \/etc\/nsswitch\.conf/d' \
-		-e '/^C \/etc\/pam\.d/d'
+		-e '/^C!* \/etc\/nsswitch\.conf/d' \
+		-e '/^C!* \/etc\/pam\.d/d'
 }
 
 migrate_locale() {

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -423,7 +423,8 @@ multilib_src_install_all() {
 	rm -rf "${ED}"/usr/share/factory
 	sed -i "${ED}"/usr/lib/tmpfiles.d/etc.conf \
 		-e '/^C!* \/etc\/nsswitch\.conf/d' \
-		-e '/^C!* \/etc\/pam\.d/d'
+		-e '/^C!* \/etc\/pam\.d/d' \
+		-e '/^C!* \/etc\/issue/d'
 }
 
 migrate_locale() {


### PR DESCRIPTION
With the latest systemd version, the lines that sed is removing now
include an exclamation mark, so adapt the sed command to accept both
formats.

These lines need to be removed so that the configuration set in
/usr/lib/tmpfiles.d/pam.conf file can be used (duplicate entries will
lead to systemd not doing anything).

Fixes: flatcar-linux/Flatcar#75