### PR TITLE
Merge changes from flatcar-master to fix missing /etc/pam.d in edge channel

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -393,8 +393,8 @@ multilib_src_install_all() {
 	# Do not ship distro-specific files (nsswitch.conf pam.d)
 	rm -rf "${ED}"/usr/share/factory
 	sed -i "${ED}"/usr/lib/tmpfiles.d/etc.conf \
-		-e '/^C \/etc\/nsswitch\.conf/d' \
-		-e '/^C \/etc\/pam\.d/d'
+		-e '/^C!* \/etc\/nsswitch\.conf/d' \
+		-e '/^C!* \/etc\/pam\.d/d'
 }
 
 migrate_locale() {

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -394,7 +394,8 @@ multilib_src_install_all() {
 	rm -rf "${ED}"/usr/share/factory
 	sed -i "${ED}"/usr/lib/tmpfiles.d/etc.conf \
 		-e '/^C!* \/etc\/nsswitch\.conf/d' \
-		-e '/^C!* \/etc\/pam\.d/d'
+		-e '/^C!* \/etc\/pam\.d/d' \
+		-e '/^C!* \/etc\/issue/d'
 }
 
 migrate_locale() {


### PR DESCRIPTION
This cherry-picks two commits already applied to flatcar-master