### PR TITLE
app-admin/flannel-wrapper: set MACAddressPolicy=none for flannel

### DIFF
--- a/app-admin/flannel-wrapper/files/50-flannel.network
+++ b/app-admin/flannel-wrapper/files/50-flannel.network
@@ -3,3 +3,4 @@ Name=flannel*
 
 [Link]
 Unmanaged=yes
+MACAddressPolicy=none


### PR DESCRIPTION
When setting up flannel interfaces, use MACAddressPolicy=none, so that
the MAC Address used is the one set by flannel and not the one assigned
by systemd.

See https://github.com/coreos/flannel/issues/1155 for more information.

This fixes the issue we saw with the vxlan test