### PR TITLE
app-admin/flannel-wrapper: Create a 50-flannel.link

### DIFF
--- a/app-admin/flannel-wrapper/files/50-flannel.link
+++ b/app-admin/flannel-wrapper/files/50-flannel.link
@@ -1,0 +1,5 @@
+[Match]
+OriginalName=flannel*
+
+[Link]
+MACAddressPolicy=none

--- a/app-admin/flannel-wrapper/files/50-flannel.network
+++ b/app-admin/flannel-wrapper/files/50-flannel.network
@@ -3,4 +3,3 @@ Name=flannel*
 
 [Link]
 Unmanaged=yes
-MACAddressPolicy=none

--- a/app-admin/flannel-wrapper/flannel-wrapper-0.11.0.ebuild
+++ b/app-admin/flannel-wrapper/flannel-wrapper-0.11.0.ebuild
@@ -41,4 +41,5 @@ src_install() {
 
 	insinto /usr/lib/systemd/network
 	doins "${FILESDIR}"/50-flannel.network
+	doins "${FILESDIR}"/50-flannel.link
 }


### PR DESCRIPTION
When setting up flannel interfaces, use MACAddressPolicy=none, so that
the MAC Address used is the initial one set by the kernel and not the
one assigned by systemd.

See coreos/flannel#1155 for more information.

In #279 we tried adding the MACAddressPolicy=none setting to the
existing 50-flannel.network file. But the change should have been in a
.link file, not a .network file.

# Testing done

I manually built the edge image, deployed it in packet and verified that ping on the flannel interface worked.