### PR TITLE
.github: detect kernel version correctly

### DIFF
--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -9,6 +9,9 @@ checkout_branches "linux-${VERSION_NEW}"
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST patch-\(${KERNEL_VERSION}.[0-9]*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
+if [[ -z "${VERSION_OLD}" ]]; then
+  VERSION_OLD=$(sed -n "s/^DIST linux-\(${KERNEL_VERSION}*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
+fi
 [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Kernel, nothing to do" && exit
 
 for pkg in sources modules kernel; do \


### PR DESCRIPTION
`kernel-apply-patch.sh` cannot detect the existing kernel version, if the version does not have a patchlevel, e.g. `5.6`. So the old kernel version variable becomes an empty string, and the final pull request has an empty field after the `from` string.

If the Manifest does not have a `patch-` line, try to read a `linux-` line again, to detect the correct kernel version.
