### PR TITLE
.github: schedule weekly Github actions for containerd

### DIFF
--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+. .github/workflows/common.sh
+
+checkout_branches "containerd-${VERSION_NEW}"
+
+pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
+
+VERSION_OLD=$(sed -n "s/^DIST containerd-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/containerd/Manifest | sort -ruV | head -n1)
+[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Docker, nothing to do" && exit
+
+DOCKER_VERSION=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
+
+# we need to update not only the main ebuild file, but also its CONTAINERD_COMMIT,
+# which needs to point to COMMIT_HASH that matches with $VERSION_NEW from upstream containerd.
+containerdEbuildOldSymlink=$(ls -1 app-emulation/containerd/containerd-${VERSION_OLD}*.ebuild | sort -ruV | head -n1)
+containerdEbuildNewSymlink="app-emulation/containerd/containerd-${VERSION_NEW}.ebuild"
+containerdEbuildMain="app-emulation/containerd/containerd-9999.ebuild"
+git mv ${containerdEbuildOldSymlink} ${containerdEbuildNewSymlink}
+sed -i "s/CONTAINERD_COMMIT=\"\(.*\)\"/CONTAINERD_COMMIT=\"${COMMIT_HASH}\"/g" ${containerdEbuildMain}
+sed -i "s/v${VERSION_OLD}/v${VERSION_NEW}/g" ${containerdEbuildMain}
+
+# torcx ebuild file has a docker version with only major and minor versions, like 19.03.
+versionTorcx=${DOCKER_VERSION%.*}
+torcxEbuildFile=$(ls -1 app-torcx/docker/docker-${versionTorcx}*.ebuild | sort -ruV | head -n1)
+sed -i "s/containerd-${VERSION_OLD}/containerd-${VERSION_NEW}/g" ${torcxEbuildFile}
+
+popd >/dev/null || exit
+
+generate_patches app-emulation containerd Containerd
+
+apply_patches
+
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"

--- a/.github/workflows/containerd-releases-alpha.yml
+++ b/.github/workflows/containerd-releases-alpha.yml
@@ -1,0 +1,47 @@
+name: Get the latest Containerd release for Alpha
+on:
+  schedule:
+    - cron:  '00 8 * * 5'
+
+jobs:
+  get-containerd-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Containerd release
+        id: fetch-latest-release
+        run: |
+          git clone https://github.com/containerd/containerd
+          versionAlpha=$(git -C containerd ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
+          commitAlpha=$(git -C containerd rev-parse v${versionAlpha})
+          rm -rf containerd
+          echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
+          echo ::set-output name=COMMIT_ALPHA::$(echo ${commitAlpha})
+          echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Alpha
+        id: apply-patch-alpha
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_ALPHA }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+        run: .github/workflows/containerd-apply-patch.sh
+      - name: Create pull request for Alpha
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          branch: containerd-${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}-alpha
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Containerd in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          commit-message: Upgrade Containerd in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          body: Upgrade Containerd in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          labels: alpha

--- a/.github/workflows/containerd-releases-edge.yml
+++ b/.github/workflows/containerd-releases-edge.yml
@@ -1,0 +1,47 @@
+name: Get the latest Containerd release for Edge
+on:
+  schedule:
+    - cron:  '05 8 * * 5'
+
+jobs:
+  get-containerd-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest Containerd release
+        id: fetch-latest-release
+        run: |
+          git clone https://github.com/containerd/containerd
+          versionEdge=$(git -C containerd ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
+          commitEdge=$(git -C containerd rev-parse v${versionEdge})
+          rm -rf containerd
+          echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
+          echo ::set-output name=COMMIT_EDGE::$(echo ${commitEdge})
+          echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        env:
+          CORK_VERSION: 0.13.2
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for Edge
+        id: apply-patch-edge
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_EDGE }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+        run: .github/workflows/containerd-apply-patch.sh
+      - name: Create pull request for Edge
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          branch: containerd-${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}-edge
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Containerd in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          commit-message: Upgrade Containerd in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          body: Upgrade Containerd in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          labels: edge

--- a/.github/workflows/docker-releases-alpha.yml
+++ b/.github/workflows/docker-releases-alpha.yml
@@ -1,7 +1,7 @@
 name: Get the latest Docker release for Alpha
 on:
   schedule:
-    - cron:  '35 7 * * *'
+    - cron:  '35 7 * * 3'
 
 jobs:
   get-docker-release:

--- a/.github/workflows/docker-releases-edge.yml
+++ b/.github/workflows/docker-releases-edge.yml
@@ -1,7 +1,7 @@
 name: Get the latest Docker release for Edge
 on:
   schedule:
-    - cron:  '40 7 * * *'
+    - cron:  '40 7 * * 3'
 
 jobs:
   get-docker-release:

--- a/.github/workflows/go-releases-alpha.yml
+++ b/.github/workflows/go-releases-alpha.yml
@@ -1,7 +1,7 @@
 name: Get the latest Go release for Alpha
 on:
   schedule:
-    - cron:  '15 7 * * *'
+    - cron:  '15 7 * * 1'
 
 jobs:
   get-go-release:

--- a/.github/workflows/go-releases-edge.yml
+++ b/.github/workflows/go-releases-edge.yml
@@ -1,7 +1,7 @@
 name: Get the latest Go release for Edge
 on:
   schedule:
-    - cron:  '20 7 * * *'
+    - cron:  '20 7 * * 1'
 
 jobs:
   get-go-release:

--- a/.github/workflows/runc-releases-alpha.yml
+++ b/.github/workflows/runc-releases-alpha.yml
@@ -1,7 +1,7 @@
 name: Get the latest Runc release for Alpha
 on:
   schedule:
-    - cron:  '50 7 * * *'
+    - cron:  '50 7 * * 4'
 
 jobs:
   get-runc-release:

--- a/.github/workflows/runc-releases-edge.yml
+++ b/.github/workflows/runc-releases-edge.yml
@@ -1,7 +1,7 @@
 name: Get the latest Runc release for Edge
 on:
   schedule:
-    - cron:  '55 7 * * *'
+    - cron:  '55 7 * * 4'
 
 jobs:
   get-runc-release:

--- a/.github/workflows/rust-release-alpha.yml
+++ b/.github/workflows/rust-release-alpha.yml
@@ -1,7 +1,7 @@
 name: Get the latest Rust release for Alpha
 on:
   schedule:
-    - cron:  '20 7 * * *'
+    - cron:  '20 7 * * 2'
 
 jobs:
   get-rust-release:

--- a/.github/workflows/rust-release-edge.yml
+++ b/.github/workflows/rust-release-edge.yml
@@ -1,7 +1,7 @@
 name: Get the latest Rust release for Edge
 on:
   schedule:
-    - cron:  '25 7 * * *'
+    - cron:  '25 7 * * 2'
 
 jobs:
   get-rust-release:


### PR DESCRIPTION
To get `containerd` in sync with upstream, we need to schedule weekly Github actions. It runs on Friday every week, only for Alpha and Edge.
Similar to those for Docker, we need to deal with torcx ebuilds as well, as they contain containerd versions.

Also change other Github actions so that they run weekly once to check for usual packages.
We do not need to run once in a day to check for updates from ordinary packages. Most releases happen once in more than a week.
Go on Mon, Rust on Tue, Docker on Wed, Runc on Thu.

Note, we still need to check for Kernel once in a day, as Kernel releases happen quite often.