### PR TITLE
coreos-base/oem-vmware: Use flatcar.autologin for the console

### DIFF
--- a/coreos-base/oem-vmware/files/grub.cfg
+++ b/coreos-base/oem-vmware/files/grub.cfg
@@ -1,3 +1,4 @@
 # Flatcar GRUB settings
 
 set oem_id="vmware"
+set linux_append="flatcar.autologin"


### PR DESCRIPTION
The user can only login via SSH if no password was set and can't login
over the VGA console in the web UI. To login the user needs to press
reboot and then append flatcar.autologin to the kernel command line parameters
in GRUB each time. The user may also not know that this option even exists.
Set flatcar.autologin by default in the kernel command line parameters for
VMware so that users don't need to set this themselves.

# How to use

Build the image and use it with VMware ESX or Workstation.

# Testing done

Tested on ESXi.

**Note:** Pick for other channels.