### PR TITLE
.github: detect latest cork version during SDK setup

### DIFF
--- a/.github/workflows/containerd-releases-alpha.yml
+++ b/.github/workflows/containerd-releases-alpha.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Alpha
         id: apply-patch-alpha

--- a/.github/workflows/containerd-releases-edge.yml
+++ b/.github/workflows/containerd-releases-edge.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Edge
         id: apply-patch-edge

--- a/.github/workflows/docker-releases-alpha.yml
+++ b/.github/workflows/docker-releases-alpha.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Alpha
         id: apply-patch-alpha

--- a/.github/workflows/docker-releases-edge.yml
+++ b/.github/workflows/docker-releases-edge.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Edge
         id: apply-patch-edge

--- a/.github/workflows/go-releases-alpha.yml
+++ b/.github/workflows/go-releases-alpha.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Alpha
         id: apply-patch-alpha

--- a/.github/workflows/go-releases-edge.yml
+++ b/.github/workflows/go-releases-edge.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Edge
         id: apply-patch-edge

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Alpha
         id: apply-patch-alpha

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_BETA::flatcar-master-beta
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Beta
         id: apply-patch-beta

--- a/.github/workflows/kernel-releases-edge.yml
+++ b/.github/workflows/kernel-releases-edge.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Edge
         id: apply-patch-edge

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -22,8 +22,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_STABLE::flatcar-master
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Stable
         id: apply-patch-stable

--- a/.github/workflows/runc-releases-alpha.yml
+++ b/.github/workflows/runc-releases-alpha.yml
@@ -23,8 +23,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Alpha
         id: apply-patch-alpha

--- a/.github/workflows/runc-releases-edge.yml
+++ b/.github/workflows/runc-releases-edge.yml
@@ -23,8 +23,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Edge
         id: apply-patch-edge

--- a/.github/workflows/rust-release-alpha.yml
+++ b/.github/workflows/rust-release-alpha.yml
@@ -20,8 +20,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Alpha
         id: apply-patch-alpha

--- a/.github/workflows/rust-release-edge.yml
+++ b/.github/workflows/rust-release-edge.yml
@@ -20,8 +20,6 @@ jobs:
           echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
-        env:
-          CORK_VERSION: 0.13.2
         run: .github/workflows/setup-flatcar-sdk.sh
       - name: Apply patch for Edge
         id: apply-patch-edge

--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+CORK_VERSION=$(curl -s https://api.github.com/repos/flatcar-linux/mantle/releases/latest | jq -r .tag_name | sed -e 's/^v//')
 curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64
 curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64.sig
 gpg --keyserver keys.gnupg.net --receive-keys 84C8E771C0DF83DFBFCAAAF03ADA89DEC2507883


### PR DESCRIPTION
We do not need to specify a cork version from each Github action.
Simply detect the latest version in `setup-flatcar-sdk.sh`, before downloading cork binary file from Github.

Also remove the env variable for cork version from each Github action.
