### PR TITLE
profile: set python 3.6 single target for cross builds for edge

### DIFF
--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -29,3 +29,6 @@ sys-libs/ncurses static-libs
 sys-libs/zlib static-libs
 virtual/jpeg static-libs
 x11-libs/pixman static-libs
+
+cross-x86_64-cros-linux-gnu/gdb python_single_target_python3_6 -python_single_target_python3_7
+cross-aarch64-cros-linux-gnu/gdb python_single_target_python3_6 -python_single_target_python3_7


### PR DESCRIPTION
Now that `cross-{x86_64,aarch64}-cros-linux-gnu/gdb` was updated to 9.1, it needs exactly one of `python_single_target_python3_6` and `python_single_target_python3_7`.
Since python 3.7 is not available yet, we need to enable 3.6 and disable 3.7, for the SDK profile.

Without the fix, toolchain builds will fail like that:

```
!!! The ebuild selected to satisfy "cross-aarch64-cros-linux-gnu/gdb"
has unmet requirements.
- cross-aarch64-cros-linux-gnu/gdb-9.1-r1::x-crossdev USE="client nls python server -lzma -multitarget -source-highlight -test -vanilla -xml -xxhash"
  PYTHON_SINGLE_TARGET="-python3_6 (-python3_7)" PYTHON_TARGETS="python3_6 (-python3_7)"

  The following REQUIRED_USE flag constraints are unsatisfied:
    python? ( exactly-one-of ( python_single_target_python3_6 python_single_target_python3_7 ) )

  The above constraints are a subset of the following complete expression:
    python? ( exactly-one-of ( python_single_target_python3_6 python_single_target_python3_7 )
              python_single_target_python3_6? ( python_targets_python3_6)
              python_single_target_python3_7? ( python_targets_python3_7 ) ) any-of ( client server )
```

## How to test

Clean up everything in the SDK, and set up the board from scratch.

```
setup_board --board=amd64-usr
setup_board --board=arm64-usr
```