### PR TITLE
Set oniguruma USE flag for the jq package

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -100,3 +100,6 @@ sys-apps/man-db -nls
 
 # Disable zstd to avoid adding it to prod images until something needs it
 sys-fs/btrfs-progs -zstd
+
+# enable regular expression processing in jq
+app-misc/jq oniguruma


### PR DESCRIPTION
See https://github.com/flatcar-linux/Flatcar/issues/101

This PR adds ONIGURUMA regex libary to support regular expressions in jq tool

# How to use

See https://github.com/flatcar-linux/Flatcar/issues/101 for the testcase


# Testing done

Tested with local SDK setup. After rebuild i see that it is linked with libonig library:
```
builder@localhost ~/trunk/src/scripts $ ldd /mnt/host/source/chroot/build/amd64-usr/usr/bin/jq
	linux-vdso.so.1 (0x00007ffe54d57000)
	libjq.so.1 => /usr/lib64/libjq.so.1 (0x00007efc495b8000)
	libc.so.6 => /lib64/libc.so.6 (0x00007efc493e0000)
	libm.so.6 => /lib64/libm.so.6 (0x00007efc49296000)
	libonig.so.5 => /usr/lib64/libonig.so.5 (0x00007efc49205000)
	/lib64/ld-linux-x86-64.so.2 (0x00007efc49614000)
```
Also test from my testcase is now passing:
```
builder@localhost ~/trunk/src/scripts $ echo '["xabcd", "ABC"]'| /mnt/host/source/chroot/build/amd64-usr/usr/bin/jq '.[] | test("a b c # spaces are ignored"; "ix")'
true
true
```
