### PR TITLE
profiles: bump edk2-ovmf to 201905 for edge

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -73,7 +73,7 @@ dev-util/checkbashisms
 
 =net-firewall/iptables-1.6.2-r2 ~arm64
 
-=sys-firmware/edk2-ovmf-2017_p20180211 ~arm64
+=sys-firmware/edk2-ovmf-201905 ~arm64
 
 =sys-auth/google-oslogin-20180611 **
 


### PR DESCRIPTION
Now that edk2-ovmf was updated to 201905, we need to also fix edk2-ovmf
to 201905 for ~arm64, so we can avoid build errors.

## how to test

```
sudo emerge -1 edk2-ovmf
emerge --emptytree -p -v --tree coreos-base/hard-host-depends coreos-devel/sdk-depends
```