### PR TITLE
profiles: enable fero-client for alpha

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -74,3 +74,5 @@ dev-util/checkbashisms
 =net-misc/openssh-8.1_p1-r3 ~arm64
 
 =sys-firmware/sgabios-0.1_pre8-r1 ~amd64 ~arm64
+
+=coreos-devel/fero-client-0.1.1 **


### PR DESCRIPTION
Since fero-client pulls in `virtual/rust` and other rust-related packages, we need to enable keywords for fero-client.

## how to test

```
emerge --emptytree -p -v coreos-base/hard-host-depends coreos-devel/sdk-depends
```