### PR TITLE
coreos-base/oem-azure: Use flatcar.autologin for the serial console

### DIFF
--- a/coreos-base/oem-azure/files/grub.cfg
+++ b/coreos-base/oem-azure/files/grub.cfg
@@ -3,7 +3,7 @@
 set oem_id="azure"
 
 # Azure only has a serial console.
-set linux_console="console=ttyS0,115200n8 earlyprintk=ttyS0,115200"
+set linux_console="console=ttyS0,115200n8 earlyprintk=ttyS0,115200 flatcar.autologin"
 serial com0 --speed=115200 --word=8 --parity=no
 terminal_input serial_com0
 terminal_output serial_com0


### PR DESCRIPTION
The user can only login via SSH if no password was set and can't login
over the serial console in the web UI. To login, the user needs to press
reboot and then append flatcar.autologin to the kernel command line parameters
in GRUB each time. The user may also not know that this option even exists.
Set flatcar.autologin by default in the kernel command line parameters for
Azure so that users don't need to set this themselves.


# How to use

Deploy a VM on Azure with an image built from this branch (e.g., use `kola spawn --platform azure --azure-image-file FILENAME …`).
Click on the VM in the web UI and select _Serial console_ from the menu, there you see the prompt (hit Enter a few times if log messages were printed over the prompt).

# Testing done

I modified the file manually in the OEM partition and rebooted for it to take effect.

Note: Pick for all channels.