### PR TITLE
coreos-base/coreos-init: Point to latest flatcar-master

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="6fe882b9dea61583ef067f648b29198fa1ebe034" # flatcar-master
+	CROS_WORKON_COMMIT="98350eee4a945f40b8a04de62bb46ea059a8d8fa" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Pulls in https://github.com/flatcar-linux/init/pull/18 to describe
that setting OEM uses an OEM image.

Note: Pick for all channels.