### PR TITLE
.github: skip branch checkout if it exists

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -15,10 +15,16 @@ function enter() ( cd ../../..; exec cork enter -- $@ )
 function checkout_branches() {
   TARGET_BRANCH=$1
 
-  [[ -z "${TARGET_BRANCH}" ]] && echo "No target branch specified. exit." && exit 1
+  [[ -z "${TARGET_BRANCH}" ]] && echo "No target branch specified. exit." && exit 0
 
   git -C "${SDK_OUTER_SRCDIR}/scripts" checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
   git -C "${SDK_OUTER_SRCDIR}/third_party/portage-stable" checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
+
+  if git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" show-ref "remotes/github/${TARGET_BRANCH}"; then
+    echo "Target branch already exists. exit.";
+    exit 0
+  fi
+
   git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" checkout -B "${TARGET_BRANCH}" "github/${BASE_BRANCH}"
 }
 

--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -2,14 +2,16 @@
 
 set -euo pipefail
 
+UPDATE_NEEDED=1
+
 . .github/workflows/common.sh
 
-checkout_branches "containerd-${VERSION_NEW}-${CHANNEL}"
+checkout_branches "containerd-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST containerd-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/containerd/Manifest | sort -ruV | head -n1)
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Docker, nothing to do" && exit
+[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Docker, nothing to do" && UPDATE_NEEDED=0 && exit 0
 
 DOCKER_VERSION=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
 
@@ -34,3 +36,4 @@ generate_patches app-emulation containerd Containerd
 apply_patches
 
 echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
+echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"

--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 . .github/workflows/common.sh
 
-checkout_branches "containerd-${VERSION_NEW}"
+checkout_branches "containerd-${VERSION_NEW}-${CHANNEL}"
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 

--- a/.github/workflows/containerd-releases-alpha.yml
+++ b/.github/workflows/containerd-releases-alpha.yml
@@ -34,6 +34,7 @@ jobs:
         run: .github/workflows/containerd-apply-patch.sh
       - name: Create pull request for Alpha
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-alpha.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}

--- a/.github/workflows/containerd-releases-alpha.yml
+++ b/.github/workflows/containerd-releases-alpha.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Alpha
         id: apply-patch-alpha
         env:
+          CHANNEL: alpha
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
           COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_ALPHA }}

--- a/.github/workflows/containerd-releases-edge.yml
+++ b/.github/workflows/containerd-releases-edge.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Edge
         id: apply-patch-edge
         env:
+          CHANNEL: edge
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
           COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_EDGE }}

--- a/.github/workflows/containerd-releases-edge.yml
+++ b/.github/workflows/containerd-releases-edge.yml
@@ -34,6 +34,7 @@ jobs:
         run: .github/workflows/containerd-apply-patch.sh
       - name: Create pull request for Edge
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-edge.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 . .github/workflows/common.sh
 
-checkout_branches "docker-${VERSION_NEW}"
+checkout_branches "docker-${VERSION_NEW}-${CHANNEL}"
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 

--- a/.github/workflows/docker-releases-alpha.yml
+++ b/.github/workflows/docker-releases-alpha.yml
@@ -34,6 +34,7 @@ jobs:
         run: .github/workflows/docker-apply-patch.sh
       - name: Create pull request for Alpha
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-alpha.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}

--- a/.github/workflows/docker-releases-alpha.yml
+++ b/.github/workflows/docker-releases-alpha.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Alpha
         id: apply-patch-alpha
         env:
+          CHANNEL: alpha
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
           COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_ALPHA }}

--- a/.github/workflows/docker-releases-edge.yml
+++ b/.github/workflows/docker-releases-edge.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Edge
         id: apply-patch-edge
         env:
+          CHANNEL: edge
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
           COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_EDGE }}

--- a/.github/workflows/docker-releases-edge.yml
+++ b/.github/workflows/docker-releases-edge.yml
@@ -34,6 +34,7 @@ jobs:
         run: .github/workflows/docker-apply-patch.sh
       - name: Create pull request for Edge
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-edge.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -7,7 +7,7 @@ VERSION_SHORT=${VERSION_NEW%.*}
 
 . .github/workflows/common.sh
 
-checkout_branches "go-${VERSION_NEW}"
+checkout_branches "go-${VERSION_NEW}-${CHANNEL}"
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -2,13 +2,16 @@
 
 set -euo pipefail
 
+# trim the 3rd part in the input semver, e.g. from 1.14.3 to 1.14
+VERSION_SHORT=${VERSION_NEW%.*}
+
 . .github/workflows/common.sh
 
 checkout_branches "go-${VERSION_NEW}"
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
-VERSION_OLD=$(sed -n "s/^DIST go\(${GO_VERSION}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
+VERSION_OLD=$(sed -n "s/^DIST go\(${VERSION_SHORT}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
 [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Go, nothing to do" && exit
 
 git mv $(ls -1 dev-lang/go/go-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "dev-lang/go/go-${VERSION_NEW}.ebuild"

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -4,15 +4,16 @@ set -euo pipefail
 
 # trim the 3rd part in the input semver, e.g. from 1.14.3 to 1.14
 VERSION_SHORT=${VERSION_NEW%.*}
+UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
-checkout_branches "go-${VERSION_NEW}-${CHANNEL}"
+checkout_branches "go-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST go\(${VERSION_SHORT}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Go, nothing to do" && exit
+[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Go, nothing to do" && UPDATE_NEEDED=0 && exit 0
 
 git mv $(ls -1 dev-lang/go/go-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "dev-lang/go/go-${VERSION_NEW}.ebuild"
 
@@ -23,3 +24,4 @@ generate_patches dev-lang go Go
 apply_patches
 
 echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
+echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"

--- a/.github/workflows/go-releases-alpha.yml
+++ b/.github/workflows/go-releases-alpha.yml
@@ -33,6 +33,7 @@ jobs:
         run: .github/workflows/go-apply-patch.sh
       - name: Create pull request for Alpha
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-alpha.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}

--- a/.github/workflows/go-releases-alpha.yml
+++ b/.github/workflows/go-releases-alpha.yml
@@ -27,7 +27,6 @@ jobs:
         id: apply-patch-alpha
         env:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
-          GO_VERSION: 1.13
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
         run: .github/workflows/go-apply-patch.sh

--- a/.github/workflows/go-releases-alpha.yml
+++ b/.github/workflows/go-releases-alpha.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Alpha
         id: apply-patch-alpha
         env:
+          CHANNEL: alpha
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}

--- a/.github/workflows/go-releases-edge.yml
+++ b/.github/workflows/go-releases-edge.yml
@@ -27,7 +27,6 @@ jobs:
         id: apply-patch-edge
         env:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
-          GO_VERSION: 1.13
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
         run: .github/workflows/go-apply-patch.sh

--- a/.github/workflows/go-releases-edge.yml
+++ b/.github/workflows/go-releases-edge.yml
@@ -33,6 +33,7 @@ jobs:
         run: .github/workflows/go-apply-patch.sh
       - name: Create pull request for Edge
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-edge.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}

--- a/.github/workflows/go-releases-edge.yml
+++ b/.github/workflows/go-releases-edge.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Edge
         id: apply-patch-edge
         env:
+          CHANNEL: edge
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -2,15 +2,18 @@
 
 set -euo pipefail
 
+# trim the 3rd part in the input semver, e.g. from 5.4.1 to 5.4
+VERSION_SHORT=${VERSION_NEW%.*}
+
 . .github/workflows/common.sh
 
 checkout_branches "linux-${VERSION_NEW}"
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
-VERSION_OLD=$(sed -n "s/^DIST patch-\(${KERNEL_VERSION}.[0-9]*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
+VERSION_OLD=$(sed -n "s/^DIST patch-\(${VERSION_SHORT}.[0-9]*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
 if [[ -z "${VERSION_OLD}" ]]; then
-  VERSION_OLD=$(sed -n "s/^DIST linux-\(${KERNEL_VERSION}*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
+  VERSION_OLD=$(sed -n "s/^DIST linux-\(${VERSION_SHORT}*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
 fi
 [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Kernel, nothing to do" && exit
 

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -7,7 +7,7 @@ VERSION_SHORT=${VERSION_NEW%.*}
 
 . .github/workflows/common.sh
 
-checkout_branches "linux-${VERSION_NEW}"
+checkout_branches "linux-${VERSION_NEW}-${CHANNEL}"
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Alpha
         id: apply-patch-alpha
         env:
+          CHANNEL: alpha
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -33,6 +33,7 @@ jobs:
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for Alpha
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-alpha.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -27,7 +27,6 @@ jobs:
         id: apply-patch-alpha
         env:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
-          KERNEL_VERSION: 5.4
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
         run: .github/workflows/kernel-apply-patch.sh

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -27,7 +27,6 @@ jobs:
         id: apply-patch-beta
         env:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_BETA }}
-          KERNEL_VERSION: 4.19
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_BETA }}
         run: .github/workflows/kernel-apply-patch.sh

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -33,6 +33,7 @@ jobs:
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for Beta
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-beta.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_BETA }}

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Beta
         id: apply-patch-beta
         env:
+          CHANNEL: beta
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_BETA }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_BETA }}

--- a/.github/workflows/kernel-releases-edge.yml
+++ b/.github/workflows/kernel-releases-edge.yml
@@ -33,6 +33,7 @@ jobs:
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for Edge
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-edge.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}

--- a/.github/workflows/kernel-releases-edge.yml
+++ b/.github/workflows/kernel-releases-edge.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Edge
         id: apply-patch-edge
         env:
+          CHANNEL: edge
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}

--- a/.github/workflows/kernel-releases-edge.yml
+++ b/.github/workflows/kernel-releases-edge.yml
@@ -27,7 +27,6 @@ jobs:
         id: apply-patch-edge
         env:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
-          KERNEL_VERSION: 5.6
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
         run: .github/workflows/kernel-apply-patch.sh

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Apply patch for Stable
         id: apply-patch-stable
         env:
+          CHANNEL: stable
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_STABLE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_STABLE }}

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -27,7 +27,6 @@ jobs:
         id: apply-patch-stable
         env:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_STABLE }}
-          KERNEL_VERSION: 4.19
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_STABLE }}
         run: .github/workflows/kernel-apply-patch.sh

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -33,6 +33,7 @@ jobs:
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for Stable
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-stable.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_STABLE }}

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 . .github/workflows/common.sh
 
-checkout_branches "runc-${VERSION_NEW}"
+checkout_branches "runc-${VERSION_NEW}-${CHANNEL}"
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 

--- a/.github/workflows/runc-releases-alpha.yml
+++ b/.github/workflows/runc-releases-alpha.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Apply patch for Alpha
         id: apply-patch-alpha
         env:
+          CHANNEL: alpha
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}

--- a/.github/workflows/runc-releases-alpha.yml
+++ b/.github/workflows/runc-releases-alpha.yml
@@ -34,6 +34,7 @@ jobs:
         run: .github/workflows/runc-apply-patch.sh
       - name: Create pull request for Alpha
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-alpha.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}

--- a/.github/workflows/runc-releases-edge.yml
+++ b/.github/workflows/runc-releases-edge.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Apply patch for Edge
         id: apply-patch-edge
         env:
+          CHANNEL: edge
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}

--- a/.github/workflows/runc-releases-edge.yml
+++ b/.github/workflows/runc-releases-edge.yml
@@ -34,6 +34,7 @@ jobs:
         run: .github/workflows/runc-apply-patch.sh
       - name: Create pull request for Edge
         uses: peter-evans/create-pull-request@v2
+        if: steps.apply-patch-edge.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 . .github/workflows/common.sh
 
-checkout_branches "rust-${VERSION_NEW}"
+checkout_branches "rust-${VERSION_NEW}-${CHANNEL}"
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -2,15 +2,16 @@
 
 set -euo pipefail
 
+UPDATE_NEEDED=1
+
 . .github/workflows/common.sh
 
-checkout_branches "rust-${VERSION_NEW}-${CHANNEL}"
+checkout_branches "rust-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
-updateNeeded=1
 VERSION_OLD=$(sed -n "s/^DIST rustc-\(1.[0-9]*.[0-9]*\).*/\1/p" dev-lang/rust/Manifest | sort -ruV | head -n1)
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Rust, nothing to do" && updateNeeded=0 && exit
+[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Rust, nothing to do" && UPDATE_NEEDED=0 && exit 0
 
 pushd "dev-lang/rust" >/dev/null || exit
 git mv $(ls -1 rust-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "rust-${VERSION_NEW}.ebuild"
@@ -23,4 +24,4 @@ generate_patches dev-lang rust Rust
 apply_patches
 
 echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
-echo ::set-output name=UPDATE_NEEDED::"${updateNeeded}"
+echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"

--- a/.github/workflows/rust-release-alpha.yml
+++ b/.github/workflows/rust-release-alpha.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Apply patch for Alpha
         id: apply-patch-alpha
         env:
+          CHANNEL: alpha
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}

--- a/.github/workflows/rust-release-edge.yml
+++ b/.github/workflows/rust-release-edge.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Apply patch for Edge
         id: apply-patch-edge
         env:
+          CHANNEL: edge
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}


### PR DESCRIPTION
In case the target branch already exists, `checkout_branch()` needs to simply `exit 0`, so the subsequent steps could be skipped.
In that case, it has to set `UPDATE_NEEDED` to 0, so the Github action could avoiding creating another PR.

It resolves occasional issues that happen when subsequent PRs overwrite existing open PRs made on the very same version.
It would be no problem if there was no change in the PR.
However, if there was any manual change in the previous open PR, the change will be simply overwritten. That would be very unfortunate.
