### PR TITLE
sys-kernel/bootengine: bump to fix the sysroot-boot service race

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="607494d147489b6fe16eef1cd9494f5f11d85fc0"  # flatcar-master
+	CROS_WORKON_COMMIT="2bfa9d1d4cf52bf61a5ba77c6d713b84348de511"  # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Fixes https://github.com/flatcar-linux/Flatcar/issues/83.

This is a follow up from https://github.com/flatcar-linux/bootengine/pull/12.

Fixes a race between switching root and unmounting a boot mountpoint with a tool existing only in the old root.

# How to use

The repro is described in the issue linked above.

# Testing done

Same as in the PR linked above.
