### PR TITLE
.github: correctly check status of checkout_branches

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -15,14 +15,14 @@ function enter() ( cd ../../..; exec cork enter -- $@ )
 function checkout_branches() {
   TARGET_BRANCH=$1
 
-  [[ -z "${TARGET_BRANCH}" ]] && echo "No target branch specified. exit." && exit 0
+  [[ -z "${TARGET_BRANCH}" ]] && echo "No target branch specified. exit." && return 1
 
   git -C "${SDK_OUTER_SRCDIR}/scripts" checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
   git -C "${SDK_OUTER_SRCDIR}/third_party/portage-stable" checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
 
   if git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" show-ref "remotes/github/${TARGET_BRANCH}"; then
     echo "Target branch already exists. exit.";
-    exit 0
+    return 1
   fi
 
   git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" checkout -B "${TARGET_BRANCH}" "github/${BASE_BRANCH}"

--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -6,12 +6,19 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
-checkout_branches "containerd-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
+if ! checkout_branches "containerd-${VERSION_NEW}-${CHANNEL}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST containerd-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/containerd/Manifest | sort -ruV | head -n1)
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Docker, nothing to do" && UPDATE_NEEDED=0 && exit 0
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest Containerd, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 DOCKER_VERSION=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
 

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -6,12 +6,19 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
-checkout_branches "docker-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
+if ! checkout_branches "docker-${VERSION_NEW}-${CHANNEL}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Docker, nothing to do" && UPDATE_NEEDED=0 && exit 0
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest Docker, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 # we need to update not only the main ebuild file, but also its DOCKER_GITCOMMIT,
 # which needs to point to COMMIT_HASH that matches with $VERSION_NEW from upstream docker-ce.

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -8,12 +8,19 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
-checkout_branches "go-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
+if ! checkout_branches "go-${VERSION_NEW}-${CHANNEL}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST go\(${VERSION_SHORT}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Go, nothing to do" && UPDATE_NEEDED=0 && exit 0
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest Go, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 git mv $(ls -1 dev-lang/go/go-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "dev-lang/go/go-${VERSION_NEW}.ebuild"
 

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -8,7 +8,10 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
-checkout_branches "linux-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
+if ! checkout_branches "linux-${VERSION_NEW}-${CHANNEL}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
@@ -16,7 +19,11 @@ VERSION_OLD=$(sed -n "s/^DIST patch-\(${VERSION_SHORT}.[0-9]*\).*/\1/p" sys-kern
 if [[ -z "${VERSION_OLD}" ]]; then
   VERSION_OLD=$(sed -n "s/^DIST linux-\(${VERSION_SHORT}*\).*/\1/p" sys-kernel/coreos-sources/Manifest)
 fi
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Kernel, nothing to do" && UPDATE_NEEDED=0 && exit 0
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest Kernel, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 for pkg in sources modules kernel; do \
   pushd "sys-kernel/coreos-${pkg}" >/dev/null || exit; \

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -6,7 +6,10 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
-checkout_branches "runc-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
+if ! checkout_branches "runc-${VERSION_NEW}-${CHANNEL}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
@@ -14,7 +17,11 @@ pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 # We need some sed tweaks like adding underscore, sort, and trim the underscore again,
 # so that sort -V can give the newest version including non-rc versions.
 VERSION_OLD=$(sed -n "s/^DIST docker-runc-\([0-9]*.[0-9]*.*\)\.tar.*/\1/p" app-emulation/docker-runc/Manifest | sed '/-/!{s/$/_/}' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Runc, nothing to do" && UPDATE_NEEDED=0 && exit 0
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest Runc, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 runcEbuildOld=$(ls -1 app-emulation/docker-runc/docker-runc-${VERSION_OLD}*.ebuild | sort -ruV | head -n1)
 runcEbuildNew="app-emulation/docker-runc/docker-runc-${VERSION_NEW}.ebuild"

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -6,12 +6,19 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
-checkout_branches "rust-${VERSION_NEW}-${CHANNEL}" || UPDATE_NEEDED=0 && exit 0
+if ! checkout_branches "rust-${VERSION_NEW}-${CHANNEL}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
 VERSION_OLD=$(sed -n "s/^DIST rustc-\(1.[0-9]*.[0-9]*\).*/\1/p" dev-lang/rust/Manifest | sort -ruV | head -n1)
-[[ "${VERSION_NEW}" = "${VERSION_OLD}" ]] && echo "already the latest Rust, nothing to do" && UPDATE_NEEDED=0 && exit 0
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest Rust, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
 
 pushd "dev-lang/rust" >/dev/null || exit
 git mv $(ls -1 rust-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "rust-${VERSION_NEW}.ebuild"


### PR DESCRIPTION
`exit` command will simply fail the whole script, so it would not be possible to check for status of `checkout_branches`.
Instead, we need to use `return` for the error checks.
