### PR TITLE
sys-kernel/bootengine: Point to latest flatcar-master

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="2bfa9d1d4cf52bf61a5ba77c6d713b84348de511"  # flatcar-master
+	CROS_WORKON_COMMIT="8043da392dea21dbcaac57256d7c0a78e270bc53"  # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Pulls in https://github.com/flatcar-linux/bootengine/pull/13
