### PR TITLE
app-emulation/docker: Fix URLs for docker-ce tarballs for alpha

### DIFF
--- a/app-emulation/docker-runc/docker-runc-1.0.0_rc10.ebuild
+++ b/app-emulation/docker-runc/docker-runc-1.0.0_rc10.ebuild
@@ -7,7 +7,7 @@ GITHUB_URI="github.com/opencontainers/runc"
 COREOS_GO_PACKAGE="${GITHUB_URI}"
 COREOS_GO_VERSION="go1.13"
 # the commit of runc that docker uses.
-# see https://github.com/docker/docker-ce/blob/v19.03.8-ce/components/engine/hack/dockerfile/install/runc.installer#L4
+# see https://github.com/docker/docker-ce/blob/v19.03.8/components/engine/hack/dockerfile/install/runc.installer#L4
 # Update the patch number when this commit is changed (i.e. the _p in the ebuild).
 # The patch version is arbitrarily the number of commits since the tag version
 # specified in the ebuild name. For example:

--- a/app-emulation/docker/docker-9999.ebuild
+++ b/app-emulation/docker/docker-9999.ebuild
@@ -15,9 +15,9 @@ if [[ ${PV} = *9999* ]]; then
 else
 	inherit versionator
 	if [ "$(get_version_component_count)" = 4 ]; then
-		MY_PV="$(replace_version_separator 3 '-ce-')"
+		MY_PV="$(replace_version_separator 3 '-')"
 	else
-		MY_PV="$PV-ce"
+		MY_PV="$PV"
 	fi
 	DOCKER_GITCOMMIT="9368c53"
 	SRC_URI="https://${COREOS_GO_PACKAGE}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"

--- a/metadata/md5-cache/app-emulation/docker-19.03.8
+++ b/metadata/md5-cache/app-emulation/docker-19.03.8
@@ -10,6 +10,6 @@ RDEPEND=>=dev-db/sqlite-3.7.9:3 device-mapper? ( >=sys-fs/lvm2-2.02.89[thin] ) s
 REQUIRED_USE=go_version_go1_12
 RESTRICT=installsources strip
 SLOT=0
-SRC_URI=https://github.com/docker/docker-ce/archive/v19.03.8-ce.tar.gz -> docker-19.03.8.tar.gz
+SRC_URI=https://github.com/docker/docker-ce/archive/v19.03.8.tar.gz -> docker-19.03.8.tar.gz
 _eclasses_=bash-completion-r1	47a7402d95930413ce25ba8d857339bb	coreos-go-depend	90f5716bc80a5aea57dbb393aa0cabdf	coreos-go-utils	67004337b6f831adc5f1ff107ee2f157	desktop	b1d22ac8bdd4679ab79c71aca235009d	eapi7-ver	756b3f27d8e46131d5cf3c51bd876446	epatch	a1bf4756dba418a7238f3be0cb010c54	estack	43ddf5aaffa7a8d0482df54d25a66a1f	eutils	6e6c2737b59a4b982de6fb3ecefd87f8	flag-o-matic	a09389deba2c0a7108b581e02c7cecbf	linux-info	953c3b1c472dcadbf62098a9301327f2	ltprune	2729691420b6deeda2a90b1f1183fb55	multilib	1d91b03d42ab6308b5f4f6b598ed110e	preserve-libs	ef207dc62baddfddfd39a164d9797648	systemd	71fd8d2065d102753fb9e4d20eaf3e9f	toolchain-funcs	8c7f9d80beedd16f2e5a7f612c609529	udev	7752f306eec7b286d00bdb47b763e7ac	user	7b7fc6ec5eb1c1eee55b0609f01e7362	user-info	a2abd4e2f4c3b9b06d64bf1329359a02	vcs-clean	2a0f74a496fa2b1552c4f3398258b7bf	versionator	2352c3fc97241f6a02042773c8287748
 _md5_=dc859efdc77d5263925591b349541968


### PR DESCRIPTION
Since docker-ce v18.09, the upstream repo github.com/docker/docker-ce has changed its way of version tagging, from `$VERSION-ce` to `$VERSION`.
As a result, e.g. for v19.03.8, https://github.com/docker/docker-ce/archive/v19.03.8-ce.tar.gz is not valid any more. It must be actually https://github.com/docker/docker-ce/archive/v19.03.8.tar.gz.

So we need to remove the suffix `-ce` from every version since v18.09.
