### PR TITLE
app-emulation/docker: set go1.13 in DOCKER_BUILDTAGS for edge

### DIFF
--- a/app-emulation/docker/docker-9999.ebuild
+++ b/app-emulation/docker/docker-9999.ebuild
@@ -231,6 +231,10 @@ src_compile() {
 		fi
 	done
 
+	# need to set go1.13 in DOCKER_BUILDTAGS, to avoid build
+	# failures caused by github.com/pkg/errors >= 0.9.1.
+	DOCKER_BUILDTAGS+=" go1.13"
+
 	pushd components/engine || die
 
 	if use hardened; then


### PR DESCRIPTION
Since Docker >= 19.03.9 started to depend on `github.com/pkg/errors` v0.9.1 or newer, it is now necessary to set `go1.13` in `DOCKER_BUILDTAGS`.
Otherwise, it cannot find `Is` function.

See also https://github.com/pkg/errors/blob/v0.9.1/go113.go#L16 .

## How to use

```
./build_packages
```