### PR TITLE
sys-apps/systemd: Manually enable the getty service

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -385,6 +385,10 @@ multilib_src_install_all() {
 	systemd_enable_service multi-user.target systemd-resolved.service
 	systemd_enable_service sysinit.target systemd-timesyncd.service
 
+	# enable getty manually
+	mkdir --parents "${ED}/usr/lib/systemd/system/getty.target.wants"
+	dosym ../getty@.service "/usr/lib/systemd/system/getty.target.wants/getty@tty1.service"
+
 	# Do not enable random services if /etc was detected as empty!!!
 	rm "${ED}$(usex split-usr '' /usr)/lib/systemd/system-preset/90-systemd.preset" || die
 	insinto $(usex split-usr '' /usr)/lib/systemd/system-preset


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# sys-apps/systemd: Enable the getty if not already enabled

With systemd 243, few of the services from whom the symlinks were created automatically are no longer created and a `systemctl preset-all` is recommended to run after the installation

From what I saw in the [Gentoo ebuild](https://github.com/flatcar-linux/coreos-overlay/blob/flatcar-master-alpha/sys-apps/systemd/systemd-9999.ebuild#L499-L500) - In case of installation, if the package is [replacing an outdated package](https://github.com/flatcar-linux/coreos-overlay/blob/flatcar-master-alpha/sys-apps/systemd/systemd-9999.ebuild#L497), it then enables the `getty` and `remote-fs`and then recommends running `preset-all`

On the other hand, I checked Fedora where it runs `systemctl preset-all` upon installation.

For fixing the issue flatcar-linux/Flatcar#131, rather than running `systemctl preset-all`, just enable the `getty` service.

# How to use

```bash
./build_packages
```

UPDATE: The mentioned fix does not create the appropriate location. Even though the SDK seems to contain the symlinks, the final image does not. Even tried with running `systemd preset-all` but that does not do anything. 

After doing a round of debugging realized, realized that disabling the `split-usr` use flag also fixes the issue, as with `split-usr` enabled it creates the files in `/lib` or else it creates them in `/usr/lib`. 

I believe the reason `systemd preset-all` is not working is that we are [removing the preset file that contains all the actions](https://github.com/flatcar-linux/coreos-overlay/blob/flatcar-master-alpha/sys-apps/systemd/systemd-9999.ebuild#L389). But that's just theory.

So, IMO we can merge this PR and create a seperate issue to track the non-working of `systemd preset-all`.


# Testing done

```
./image_to_vm --format=iso
```