### PR TITLE
profiles: enable bind-tools again for ARM for alpha

### DIFF
--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -15,3 +15,6 @@ app-arch/tar                selinux
 # Only ship microcode currently distributed by Intel
 # See https://bugs.gentoo.org/654638#c11 by iucode-tool maintainer
 sys-firmware/intel-microcode vanilla
+
+# Enable gssapi only for amd64, to avoid build errors in arm64.
+net-dns/bind-tools           gssapi

--- a/profiles/coreos/arm64/package.provided
+++ b/profiles/coreos/arm64/package.provided
@@ -1,6 +1,3 @@
 # arm64 provided
 
 dev-libs/gobject-introspection-1.40.0-r1
-
-# build errors
-net-dns/bind-tools-9.11.2_p1

--- a/profiles/coreos/arm64/package.use
+++ b/profiles/coreos/arm64/package.use
@@ -1,5 +1,8 @@
 # arm64 use
 
+# Disable gssapi for arm64 to avoid build errors
+net-dns/bind-tools -gssapi
+
 # FIXME: why isn't this set by default???
 sys-libs/ncurses unicode
 

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -68,7 +68,6 @@ sys-kernel/coreos-sources symlink
 # set build options for ssdp
 net-nds/openldap minimal sasl
 sys-libs/glibc nscd
-net-dns/bind-tools gssapi
 
 # disable database build because otherwise it tries to generate a database in /etc
 dev-libs/cyrus-sasl kerberos -berkdb -gdbm

--- a/sys-auth/sssd/sssd-1.13.1-r7.ebuild
+++ b/sys-auth/sssd/sssd-1.13.1-r7.ebuild
@@ -40,7 +40,7 @@ COMMON_DEP="
 		>=sys-libs/libselinux-2.1.9
 		>=sys-libs/libsemanage-2.1
 	)
-	>=net-dns/bind-tools-9.9[gssapi]
+	>=net-dns/bind-tools-9.9
 	>=dev-libs/cyrus-sasl-2.1.25-r3[kerberos]
 	>=sys-apps/dbus-1.6
 	acl? ( net-fs/cifs-utils[acl] )


### PR DESCRIPTION
`net-dns/bind-tools` has been disabled since a long time, probably because of build errors around cross-compilation for ARM. However, bind-tools binaries should be at least included in ARM images.
So enable `bind-tools` again for ARM without `gssapi` included.

To do that, disable gssapi for bind-tools only in the ARM profile, and enable gssapi only in the AMD profile.

Now that bind-tools are built with gssapi only for AMD, without gssapi for ARM, we need to get the USE flag for `sys-auth/sssd` requirement relaxed. Profile for each architecture will instead choose whether to use gssapi.

## How to use

```
emerge-arm64-usr net-dns/bind-tools sys-auth/sssd
```