### PR TITLE
coreos-devel/mantle: Use correct Apache license identifier

### DIFF
--- a/coreos-devel/mantle/mantle-9999.ebuild
+++ b/coreos-devel/mantle/mantle-9999.ebuild
@@ -19,7 +19,7 @@ inherit coreos-go cros-workon
 
 DESCRIPTION="Mantle: Gluing CoreOS together"
 HOMEPAGE="https://github.com/coreos/mantle"
-LICENSE="Apache-2"
+LICENSE="Apache-2.0"
 SLOT="0"
 # objcopy/split have trouble with our cross-compiled kolet
 STRIP_MASK="/*/kola/*/kolet"


### PR DESCRIPTION
There is no portage-stable/licenses/Apache-2 file because the
correct name for the license is Apache-2.0, and the missing
license file causes the build to fail.

# How to use/test

Run `./build_image container` in the SDK to build the developer container image.

This fails without the change because there is no `Apache-2` file in
https://github.com/coreos/portage-stable/tree/master/licenses
