### PR TITLE
net-firewall/conntrack-tools: Use same flags as Beta

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -38,8 +38,8 @@
 =net-firewall/ipset-6.29 ~arm64
 =net-libs/libmicrohttpd-0.9.52 **
 =net-libs/libnetfilter_conntrack-1.0.8 ~arm64
-=net-libs/libnetfilter_cthelper-1.0.0 ~arm64
-=net-libs/libnetfilter_cttimeout-1.0.0 ~arm64
+=net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64
+=net-libs/libnetfilter_cttimeout-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_queue-1.0.3 ~arm64
 =net-libs/libnfnetlink-1.0.1 ~arm64
 =net-libs/libnftnl-1.0.6 **


### PR DESCRIPTION
The port of the commit did introduce other arm64 flags than those
used in Beta.
Align them again.
