### PR TITLE
app-admin/*-wrapper: Only set arguments that weren't set

### DIFF
--- a/app-admin/etcd-wrapper/files/etcd-wrapper
+++ b/app-admin/etcd-wrapper/files/etcd-wrapper
@@ -30,9 +30,9 @@ require_ev_all ETCD_USER ETCD_DATA_DIR
 ETCD_IMAGE_URL="${ETCD_IMAGE_URL:-docker://quay.io/coreos/etcd}"
 ETCD_IMAGE="${ETCD_IMAGE:-${ETCD_IMAGE_URL}:${ETCD_IMAGE_TAG}}"
 
-if [[ "${ETCD_IMAGE%%/*}" == "quay.io" ]]; then
+if [[ "${ETCD_IMAGE%%/*}" == "quay.io" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q trust-keys-from-https); then
 	RKT_RUN_ARGS="${RKT_RUN_ARGS} --trust-keys-from-https"
-elif [[ "${ETCD_IMAGE%%/*}" == "docker:" ]]; then
+elif [[ "${ETCD_IMAGE%%/*}" == "docker:" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q insecure-options); then
 	RKT_RUN_ARGS="${RKT_RUN_ARGS} --insecure-options=image"
 fi
 

--- a/app-admin/flannel-wrapper/files/flannel-wrapper
+++ b/app-admin/flannel-wrapper/files/flannel-wrapper
@@ -39,9 +39,9 @@ require_ev_one FLANNEL_IMAGE FLANNEL_IMAGE_TAG
 FLANNEL_IMAGE_URL="${FLANNEL_IMAGE_URL:-${FLANNEL_IMG:-docker://quay.io/coreos/flannel}}"
 FLANNEL_IMAGE="${FLANNEL_IMAGE:-${FLANNEL_IMAGE_URL}:${FLANNEL_IMAGE_TAG}}"
 
-if [[ "${FLANNEL_IMAGE%%/*}" == "quay.io" ]]; then
+if [[ "${FLANNEL_IMAGE%%/*}" == "quay.io" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q trust-keys-from-https); then
 	RKT_RUN_ARGS="${RKT_RUN_ARGS} --trust-keys-from-https"
-elif [[ "${FLANNEL_IMAGE%%/*}" == "docker:" ]]; then
+elif [[ "${FLANNEL_IMAGE%%/*}" == "docker:" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q insecure-options); then
 	RKT_RUN_ARGS="${RKT_RUN_ARGS} --insecure-options=image"
 fi
 

--- a/app-admin/kubelet-wrapper/files/kubelet-wrapper
+++ b/app-admin/kubelet-wrapper/files/kubelet-wrapper
@@ -47,9 +47,9 @@ KUBELET_IMAGE="${KUBELET_IMAGE:-${KUBELET_IMAGE_URL}:${KUBELET_IMAGE_TAG}}"
 
 RKT_RUN_ARGS="${RKT_RUN_ARGS} ${RKT_OPTS}"
 
-if [[ "${KUBELET_IMAGE%%/*}" == "quay.io" ]]; then
+if [[ "${KUBELET_IMAGE%%/*}" == "quay.io" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q trust-keys-from-https); then
 	RKT_RUN_ARGS="${RKT_RUN_ARGS} --trust-keys-from-https"
-elif [[ "${KUBELET_IMAGE%%/*}" == "docker:" ]]; then
+elif [[ "${KUBELET_IMAGE%%/*}" == "docker:" ]] && ! (echo "${RKT_RUN_ARGS}" | grep -q insecure-options); then
 	RKT_RUN_ARGS="${RKT_RUN_ARGS} --insecure-options=image"
 fi
 


### PR DESCRIPTION
When 788f328dc752a75da08d4c6fc27d094ecb4807d5 introduced pulling from
docker by default, "--insecure-options=image" was added for all
docker registries. However, when the user also needs to set "http" as
in "--insecure-options=image,http" it will not be used because the
other argument is added as last disregarding the option was already
set by the user.
Check if the option was set by the user and only add it if it is not
provided. If the user forgets to add "image" then rkt will simply
fail and tell that this option is needed; thus no complex logic of
appending and detecting only "image" is needed. Do the same for the
"--trust-keys-from-https" option to be consistent in allowing to
overwrite it with "--trust-keys-from-https=false".

# How to use/test

```
sudo KUBELET_IMAGE_TAG=v1.9.6_coreos.2 RKT_RUN_ARGS="--insecure-options=image,http" /usr/lib64/flatcar/kubelet-wrapper
+ exec /usr/bin/rkt run --insecure-options=image,http […]
sudo KUBELET_IMAGE_TAG=v1.9.6_coreos.2 ./kubelet-wrapper
+ exec /usr/bin/rkt run --insecure-options=image […]
```

Note: Pick for all channels