### PR TITLE
app-admin/locksmith: Migrate to Go modules

### DIFF
--- a/app-admin/locksmith/locksmith-9999.ebuild
+++ b/app-admin/locksmith/locksmith-9999.ebuild
@@ -5,13 +5,13 @@ EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/locksmith"
 CROS_WORKON_LOCALNAME="locksmith"
 CROS_WORKON_REPO="git://github.com"
-COREOS_GO_PACKAGE="github.com/coreos/locksmith"
+COREOS_GO_PACKAGE="github.com/flatcar-linux/locksmith"
 inherit cros-workon systemd coreos-go
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="5d195325ece73315744bf2959f8d8717d12d52be" # flatcar-master
+	CROS_WORKON_COMMIT="085ff774311dba979a53d049f6a776e156224437" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 
@@ -24,7 +24,7 @@ SLOT="0"
 IUSE=""
 
 src_compile() {
-	go_build "${COREOS_GO_PACKAGE}/locksmithctl"
+	COREOS_GO_MOD=vendor go_build "${COREOS_GO_PACKAGE}/locksmithctl"
 }
 
 src_install() {


### PR DESCRIPTION
Pulls in
https://github.com/flatcar-linux/locksmith/pull/4

# How to use/testing done

```
emerge-amd64-usr -1 locksmith
./build_packages
./build_image
./image_to_vm […]
```

Boot up VM and check that `locksmithd` is running and `locksmithctl` binaries work.

Note: Pick for all channels.