### PR TITLE
.github: update rust versions also in profiles

### DIFF
--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -20,6 +20,9 @@ if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   exit 0
 fi
 
+# replace rust version in profiles/, e.g. package.accept_keywords.
+find profiles -name 'package.*' | xargs sed -i "s/=dev-lang\/rust-${VERSION_OLD}/=dev-lang\/rust-${VERSION_NEW}/"
+
 pushd "dev-lang/rust" >/dev/null || exit
 git mv $(ls -1 rust-${VERSION_OLD}*.ebuild | sort -ruV | head -n1) "rust-${VERSION_NEW}.ebuild"
 popd >/dev/null || exit


### PR DESCRIPTION
We need to update rust versions also in multiple files in profiles, e.g. `package.accept_keywords`.
Otherwise `emerge rust` will fail, due to mismatches between rust versions, in profiles and the actual ebuilds.
