### PR TITLE
.github/workflows: Update the kernel release edge version to 5.7

### DIFF
--- a/.github/workflows/kernel-releases-edge.yml
+++ b/.github/workflows/kernel-releases-edge.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Fetch latest Kernel release
         id: fetch-latest-release
         env:
-          KV_EDGE: 5.6
+          KV_EDGE: 5.7
         run: |
           git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
           versionEdge=$(git -C linux ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v${KV_EDGE}.[0-9]*$/s/^refs\/tags\/v//p" | sort -ruV | head -1)


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>

# .github/workflows: Update the kernel release edge version to 5.7

This should be merged after #433 is merged