### PR TITLE
Disable Predictable Network Interface Names under VMware

### DIFF
--- a/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
+++ b/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
@@ -3,7 +3,7 @@
 set oem_id="ec2"
 
 # Blacklist the Xen framebuffer module so it doesn't get loaded at boot
-# Disable `ens3` style names, so eth0 is used for both ixgbevf or xen.
+# Disable Predictable Network Interface Names (systemd.net-naming-scheme(7)), so eth0 is used for both ixgbevf or xen.
 set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0 nvme_core.io_timeout=4294967295"
 
 if [ "$grub_platform" = pc ]; then

--- a/coreos-base/oem-rackspace-onmetal/files/grub.cfg
+++ b/coreos-base/oem-rackspace-onmetal/files/grub.cfg
@@ -10,4 +10,5 @@ set timeout=15
 set linux_console="console=ttyS4,115200n8 8250.nr_uarts=5"
 
 # Blacklist MEI, the firmware is just plain broken.
+# Disable Predictable Network Interface Names (systemd.net-naming-scheme(7))
 set linux_append="modprobe.blacklist=mei_me net.ifnames=0"

--- a/coreos-base/oem-vmware/files/grub.cfg
+++ b/coreos-base/oem-vmware/files/grub.cfg
@@ -1,4 +1,6 @@
 # Flatcar GRUB settings
 
 set oem_id="vmware"
-set linux_append="flatcar.autologin"
+
+# Disable Predictable Network Interface Names (systemd.net-naming-scheme(7))
+set linux_append="flatcar.autologin net.ifnames=0"


### PR DESCRIPTION
# Disable Predictable Network Interface Names under VMware
Predictable Network Interface Names are enabled for VMware instances of Flatcar CL, whereas they are disabled for (at least) AWS/Azure instances. This leads to inconsistency of interface naming between instances across clouds (`eth0` for AWS/Azure, `ens192` for VMware). This commit brings VMware instances in line with public cloud instances and adds some consistency to comments about this configuration in the EC2 & Rackspace grub config files.


# How to use
Build the Flatcar VMware image and boot it on VMware ESXi, note the name of the primary (and probably only) network interface.

# Testing done
I am not sure how to build the image at this time, so no testing has been done. If testing is required before a review of this PR, please let me know and I'll look into building the VMware image locally.
