### PR TITLE
profiles: force to use ssl USE flag for wget

### DIFF
--- a/profiles/coreos/arm64/package.use.force
+++ b/profiles/coreos/arm64/package.use.force
@@ -1,2 +1,7 @@
 sys-auth/polkit -introspection
 sys-apps/systemd -introspection
+
+# Matt Turner <mattst88@gentoo.org> (2020-03-28)
+# wget is the default FETCHCOMMAND, and most distfiles are distributed via
+# HTTPS. Bug #611072
+net-misc/wget ssl

--- a/profiles/coreos/base/package.use.force
+++ b/profiles/coreos/base/package.use.force
@@ -3,3 +3,8 @@
 
 # Do not force this flag, we don't need XATTR_PAX
 sys-apps/portage -xattr
+
+# Matt Turner <mattst88@gentoo.org> (2020-03-28)
+# wget is the default FETCHCOMMAND, and most distfiles are distributed via
+# HTTPS. Bug #611072
+net-misc/wget ssl


### PR DESCRIPTION
When catalyst tries to fetch a file via https, wget sometimes fails to do so, with the following messages:

```
https://www.kernel.org/pub/software/scm/git/git-2.24.1.tar.xz: HTTPS
support not compiled in.
!!! Couldn't download 'git-2.24.1.tar.xz'. Aborting.
```

That probably happens because wget in some catalyst stages are compiled without `ssl` USE flag.
If a catalyst stage is lucky enough to rebuild wget with `ssl` before actually fetching a file, it would work well.
Though if not, it would fail.
It is not deterministic, and hard to reproduce.

So backport the [fix](https://github.com/gentoo/gentoo/commit/d141380b915d) from upstream Gentoo,  for both amd64 and arm64.
By setting `ssl` for wget in `package.use.force`, it is now not possible to disable `ssl` for wget.

More details: https://bugs.gentoo.org/611072
