### PR TITLE
etcd: update URL to its own org on github now

### DIFF
--- a/app-admin/etcd-wrapper/etcd-wrapper-3.3.20.ebuild
+++ b/app-admin/etcd-wrapper/etcd-wrapper-3.3.20.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit systemd
 
 DESCRIPTION="etcd (System Application Container)"
-HOMEPAGE="https://github.com/coreos/etcd"
+HOMEPAGE="https://github.com/etcd-io/etcd"
 KEYWORDS="amd64 arm64"
 
 LICENSE="Apache-2.0"

--- a/app-admin/etcd-wrapper/files/etcd-member.service
+++ b/app-admin/etcd-wrapper/files/etcd-member.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=etcd (System Application Container)
-Documentation=https://github.com/coreos/etcd
+Documentation=https://github.com/etcd-io/etcd
 Wants=network-online.target network.target
 After=network-online.target
 Conflicts=etcd.service


### PR DESCRIPTION
even though they're still building from quay.io/coreos/etcd? maybe
that'll change soon too?

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# [Title: describe the change in one sentence]

etcd has been promoted to its own org now


# How to use

click the links


# Testing done
Tested that the new links work. (and that the quay.io/coreos/etcd are  still correct as well)