### PR TITLE
Revert "profiles: force to use ssl USE flag for wget"

### DIFF
--- a/profiles/coreos/arm64/package.use.force
+++ b/profiles/coreos/arm64/package.use.force
@@ -1,7 +1,2 @@
 sys-auth/polkit -introspection
 sys-apps/systemd -introspection
-
-# Matt Turner <mattst88@gentoo.org> (2020-03-28)
-# wget is the default FETCHCOMMAND, and most distfiles are distributed via
-# HTTPS. Bug #611072
-net-misc/wget ssl

--- a/profiles/coreos/base/package.use.force
+++ b/profiles/coreos/base/package.use.force
@@ -3,8 +3,3 @@
 
 # Do not force this flag, we don't need XATTR_PAX
 sys-apps/portage -xattr
-
-# Matt Turner <mattst88@gentoo.org> (2020-03-28)
-# wget is the default FETCHCOMMAND, and most distfiles are distributed via
-# HTTPS. Bug #611072
-net-misc/wget ssl


### PR DESCRIPTION
This reverts commit 517e23ebfe96137f1482ae42f8b29fc2f1b31317.

The new USE flag `ssl` for wget resulted in a strange issue.

`wget` started to pull in `dev-libs/openssl`, which has `bindist` in its USE flag.
The catalyst stages, however, need to install wget without `bindist`.
Such mismatches resulted in errors like:

```
!!! All ebuilds that could satisfy "dev-libs/openssl:0=" for /tmp/stage1root/ have been masked.
!!! One of the following masked packages is required to complete your request:
- dev-libs/openssl-1.0.2u::coreos (masked by: bindist in RESTRICT)
```

So to fix the issue, what needs to be done is basically:

```
ACCEPT_RESTRICT=bindist USE=-bindist emerge -pv openssl openssh
```

Unfortunately it is not possible to set `accept_restrict` configs under the coreos-overlay repo.
We need to have some time to investigate why it is so.

As a hotfix, we need to revert the `ssl` USE flag for wget.
