### PR TITLE
.github: replace COMMIT_ID in runc ebuilds

### DIFF
--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -27,6 +27,7 @@ runcEbuildOld=$(ls -1 app-emulation/docker-runc/docker-runc-${VERSION_OLD}*.ebui
 runcEbuildNew="app-emulation/docker-runc/docker-runc-${VERSION_NEW}.ebuild"
 git mv ${runcEbuildOld} ${runcEbuildNew}
 sed -i "s/${VERSION_OLD}/${VERSION_NEW}/g" ${runcEbuildNew}
+sed -i "s/COMMIT_ID=\"\(.*\)\"/COMMIT_ID=\"${COMMIT_HASH}\"/g" ${runcEbuildNew}
 
 # docker-runc ebuild file has also lines of runc versions with '-' instead of '_', e.g. '1.0.0-rc10'
 VERSION_OLD_HYPHEN=${VERSION_OLD//_/-}

--- a/.github/workflows/runc-releases-alpha.yml
+++ b/.github/workflows/runc-releases-alpha.yml
@@ -13,13 +13,16 @@ jobs:
       - name: Fetch latest Runc release
         id: fetch-latest-release
         run: |
-          git clone --depth=1 --no-checkout https://github.com/opencontainers/runc
+          git clone https://github.com/opencontainers/runc
           # Get the newest runc version, including official releases and rc versions.
           # We need some sed tweaks like adding underscore, sort, and trim the underscore again,
           # so that sort -V can give the newest version including non-rc versions.
-          versionAlpha=$(git -C runc ls-remote --tags origin | cut -f2 | sed '/-/!{s/$/_/}' | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*/s/^refs\/tags\/v//p" |grep -v '\{\}$' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
+          versionAlpha=$(git -C runc ls-remote --tags origin | cut -f2 | sed '/-/!{s/$/_/}' | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*/s/^refs\/tags\/v//p" |grep -v '\{\}$' | sort -ruV | sed 's/_$//' | head -n1)
+          commitAlpha="$(git -C runc rev-parse v${versionAlpha})"
+          versionAlpha="${versionAlpha//-/_}"
           rm -rf runc
           echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
+          echo ::set-output name=COMMIT_ALPHA::$(echo ${commitAlpha})
           echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
@@ -30,6 +33,7 @@ jobs:
           CHANNEL: alpha
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_ALPHA }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
         run: .github/workflows/runc-apply-patch.sh
       - name: Create pull request for Alpha

--- a/.github/workflows/runc-releases-edge.yml
+++ b/.github/workflows/runc-releases-edge.yml
@@ -13,13 +13,16 @@ jobs:
       - name: Fetch latest Runc release
         id: fetch-latest-release
         run: |
-          git clone --depth=1 --no-checkout https://github.com/opencontainers/runc
+          git clone https://github.com/opencontainers/runc
           # Get the newest runc version, including official releases and rc versions.
           # We need some sed tweaks like adding underscore, sort, and trim the underscore again,
           # so that sort -V can give the newest version including non-rc versions.
-          versionEdge=$(git -C runc ls-remote --tags origin | cut -f2 | sed '/-/!{s/$/_/}' | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*/s/^refs\/tags\/v//p" |grep -v '\{\}$' | sort -ruV | sed 's/_$//' | head -n1 | tr '-' '_')
+          versionEdge=$(git -C runc ls-remote --tags origin | cut -f2 | sed '/-/!{s/$/_/}' | sed -n "/refs\/tags\/v[0-9]*.[0-9]*.[0-9]*/s/^refs\/tags\/v//p" |grep -v '\{\}$' | sort -ruV | sed 's/_$//' | head -n1)
+          commitEdge="$(git -C runc rev-parse v${versionEdge})"
+          versionEdge="${versionEdge//-/_}"
           rm -rf runc
           echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
+          echo ::set-output name=COMMIT_EDGE::$(echo ${commitEdge})
           echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
@@ -30,6 +33,7 @@ jobs:
           CHANNEL: edge
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_EDGE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
         run: .github/workflows/runc-apply-patch.sh
       - name: Create pull request for Edge


### PR DESCRIPTION
So far Github actions have not changed existing `COMMIT_ID` variable in runc ebuilds.
As a result, the result PRs have correct versions with wrong commit hashes.

We need to replace `COMMIT_ID` with one that matches with the new version.

To do that, clone the repo completely, since it is not possible to get the commit hash by running `git rev-parse` on a shallow cloned repo.
Parse commit from a tag with an original version with `-` as its delimiter, e.g. `v1.0.0-rc91`, because a transformed tag like `v1.0.0_rc91` does not exist in the upstream repo.
