### PR TITLE
Apply Rust changes for Beta and Stable

### DIFF
--- a/dev-lang/rust/rust-1.36.0.ebuild
+++ b/dev-lang/rust/rust-1.36.0.ebuild
@@ -140,9 +140,6 @@ src_configure() {
 	if use wasm; then
 		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
 	fi
-	if [ -f /usr/bin/aarch64-cros-linux-gnu-gcc ]; then
-		rust_targets="${rust_targets},\"aarch64-unknown-linux-gnu\""
-	fi
 	rust_targets="${rust_targets#,}"
 
 	local extended="true" tools="\"cargo\","
@@ -218,18 +215,6 @@ src_configure() {
 			EOF
 		fi
 	done
-	if [ -f /usr/bin/aarch64-cros-linux-gnu-gcc ]; then
-		printf '#!/bin/sh\naarch64-cros-linux-gnu-gcc --sysroot=/usr/aarch64-cros-linux-gnu "$@"' > ${S}/cc.sh
-		printf '#!/bin/sh\naarch64-cros-linux-gnu-g++ --sysroot=/usr/aarch64-cros-linux-gnu "$@"' > ${S}/cxx.sh
-		chmod +x ${S}/cc.sh ${S}/cxx.sh
-		cat <<- EOF >> "${S}"/config.toml
-			[target.aarch64-unknown-linux-gnu]
-			cc = "${S}/cc.sh"
-			cxx = "${S}/cxx.sh"
-			linker = "${S}/cc.sh"
-			ar = "aarch64-cros-linux-gnu-ar"
-		EOF
-	fi
 
 	if use wasm; then
 		cat <<- EOF >> "${S}"/config.toml


### PR DESCRIPTION
This collects the downstream crossdev patches we currently need in a single commit and applies it to the upstream Rust ebuild file. It was needed due to a build failure in Edge but should be in all channels. The hope is that a single commit is easy to port in the future if it's also easy to find in the beginning of the ebuild header.

See https://github.com/flatcar-linux/coreos-overlay/pull/473

Note: Pick for Stable, too. The Edge PR was picked for Alpha.

# How to use

Compile Rust in the SDK after setting up an arm64 board:
```
./setup_board --board arm64-usr
sudo emerge rust
```

# Testing done

None