### PR TITLE
bootengine: move to version with disk randomization fix

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="bf79d0fbb7a4bc3ceacc7b1b35b09ec747d4d82f"  # flatcar-master
+	CROS_WORKON_COMMIT="45a62e85b7c40e322bd814ce324e5c330e654ce0"  # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 
@@ -31,6 +31,7 @@ src_install() {
 	# re-use existing filesystem permissions during initrd creation.
 	chmod +x "${D}"/usr/lib/dracut/modules.d/10*-generator/*-generator \
 		"${D}"/usr/lib/dracut/modules.d/10diskless-generator/diskless-btrfs \
+		"${D}"/usr/lib/dracut/modules.d/30disk-uuid/disk-uuid.sh \
 		"${D}"/usr/lib/dracut/modules.d/30ignition/ignition-generator \
 		"${D}"/usr/lib/dracut/modules.d/30ignition/ignition-setup.sh \
 		"${D}"/usr/lib/dracut/modules.d/30ignition/retry-umount.sh \


### PR DESCRIPTION
# Build the latest bootengine

This version of bootengine adds a new script, so on top of moving the CROS commit id pointer, we also need to add execution permissions to the new disk-uuid script.

# How to use / Testing done

Building an image with this change plus the change in flatcar-linux/scripts#82 leads to GRUB booting successfully on a c3.medium.x86 machine followed by the disk UUID getting randomized.

WIP notice: Due to issues with current flatcar-master-alpha, I wasn't yet able to fully test this change on all platforms, I only manually tested it on Packet. Once alpha is fixed, I'll test again on all platforms.

# Coupling

This needs to be submitted after flatcar-linux/bootengine#17 is in, and together with flatcar-linux/scripts#82