### PR TITLE
sys-apps/systemd: Guard deletion of hwdb.d folder behind use flag, sys-apps/baselayout: Work around systemd-tmpfiles not finding libidn2

### DIFF
--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -25,6 +25,7 @@ IUSE="cros_host symlink-usr"
 
 # This version of baselayout replaces coreos-base
 DEPEND="sys-apps/systemd
+	net-dns/libidn2:=
 	!coreos-base/coreos-base
 	!<sys-libs/glibc-2.17-r1
 	!<=sys-libs/nss-usrfiles-2.18.1_pre"

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -379,7 +379,9 @@ multilib_src_install_all() {
 		rmdir "${ED}${rootprefix}"/sbin || die
 	fi
 
-	rm -r "${ED}${rootprefix}"/lib/udev/hwdb.d || die
+	if use hwdb; then
+		rm -r "${ED}${rootprefix}"/lib/udev/hwdb.d || die
+	fi
 
 	# Flatcar: Upstream uses keepdir commands to keep some empty
 	# directories.


### PR DESCRIPTION
- Building systemd in the SDK bootstrap failed because the hwdb.d folder
  did not exist. The upstream ebuild file has this guard:
  https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-apps/systemd/systemd-245.5.ebuild#n390

- sys-apps/baselayout: Work around systemd-tmpfiles not finding libidn2
    The baselayout ebuild file calls systemd-tmpfiles but despite that
    the systemd ebuild file depends on libidn2 through a use flag, it was
    not built early enough.
    Ensure that libidn2 is built before baselayout wants to use it.


# How to use

This change is only relevant for SDK builds.

# Testing done

The SDK built systemd but later the SDK build failed due to unrelated changes.