### PR TITLE
Build amazon-ssm-agent package but disable it for now

### DIFF
--- a/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
+++ b/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
@@ -7,31 +7,6 @@
       {
         "name": "coreos-metadata-sshkeys@.service",
         "enabled": true
-      },
-      {
-        "name": "amazon-ssm-agent.service",
-        "enabled": true,
-        "contents": "[Unit]\nDescription=amazon-ssm-agent\nAfter=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory=/usr/share/oem\nExecStart=/usr/share/oem/amazon-ssm-agent\nKillMode=process\nRestart=on-failure\nRestartForceExitStatus=SIGPIPE\nRestartSec=15min\n\n[Install]\nWantedBy=multi-user.target\n"
-      }
-    ]
-  },
-  "storage": {
-    "files": [
-      {
-        "filesystem": "root",
-        "path": "/etc/amazon/ssm/amazon-ssm-agent.json",
-        "contents": {
-          "source": "oem:///ssm/amazon-ssm-agent.json.template"
-        },
-        "mode": 292
-      },
-      {
-        "filesystem": "root",
-        "path": "/etc/amazon/ssm/seelog.xml",
-        "contents": {
-          "source": "oem:///ssm/seelog.xml.template"
-        },
-        "mode": 292
       }
     ]
   }

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
@@ -13,10 +13,6 @@ KEYWORDS="amd64 arm64 x86"
 IUSE="ec2 openstack brightbox"
 REQUIRED_USE="^^ ( ec2 openstack brightbox )"
 
-RDEPEND="
-	app-emulation/amazon-ssm-agent
-"
-
 # no source directory
 S="${WORKDIR}"
 

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2.ebuild
@@ -13,6 +13,13 @@ KEYWORDS="amd64 arm64 x86"
 IUSE="ec2 openstack brightbox"
 REQUIRED_USE="^^ ( ec2 openstack brightbox )"
 
+# TODO: The AWS SSM Agent is currently too big for the OEM partition
+# but if it fits, uncomment the following and revert
+# b6abb59c544be13e923a3e7240b5c9395c281fca
+#RDEPEND="
+#       ec2? ( app-emulation/amazon-ssm-agent )
+#"
+
 # no source directory
 S="${WORKDIR}"
 

--- a/coreos-devel/board-packages/board-packages-0.0.1.ebuild
+++ b/coreos-devel/board-packages/board-packages-0.0.1.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 		sys-boot/grub
 		sys-firmware/edk2-ovmf
 	)
+	app-emulation/amazon-ssm-agent
 	coreos-base/coreos
 	coreos-base/coreos-dev
 	"


### PR DESCRIPTION
The amazon-ssm-agent package was never built and caused the vm-matrix
    job to find no binary package.
    Build it as part of build_packages but don't install it on openstack
    or brightbox images. The plan is to add it on EC2 but currently the
    binaries are too large.

# How to use

`./build_packages
…
./build_image
./image_to_vm.sh --format=ami_vmdk …
./image_to_vm.sh --format=openstack …

# Testing done

Images build and AWS AMI runs.