### PR TITLE
README.md: Document how	to update packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,28 @@ that belong in the OEM partition. Any RDEPENDS from these packages should
 be copied to the RDEPENDS in `board-packages` to ensure they are built.
 
 `coreos-base/coreos-oem-*` are metapackages for OEM specific ACIs. 
+
+# Updating
+
+To update follow the following steps:
+
+* Remove or rename the whole folder of the package to prepare the import from
+  upstream Gentoo, not only resetting the ebuild file but also any additional
+  files like patches or downstream additions under `files`.
+* Run `~/trunk/src/scripts/update_ebuilds --portage_stable . CATEGORY/PACKAGE`
+  in the `coreos-overlay` folder to import a new version from upstream Gentoo.
+  Drop the ebuild files that you don't plan to use.
+* Commit the changes with a message like `CATEGORY/PACKAGE: Sync from Gentoo`,
+  and mention the the commit ID in the body (`git show update_ebuilds/master`).
+* Now find all downstream patches for the package by running
+  `git log CATEGORY/PACKAGE`. If everybody followed the process of resetting
+  before importing an upstream update, you only have to look for the commits
+  after the last update and port them to the new version. Otherwise you have
+  to compare the files manually to their upstream versions from older
+  [portage](https://github.com/gentoo/portage/) revisions.
+* You can combine all old and new downstream patches into a single new commit
+  with the message `CATEGORY/PACKAGE: Apply Flatcar patches` to keep the number of
+  commits to port low, or have separate commits. Make sure that you explain
+  the changes and carry the explanations from old commits over, either in the
+  commit message, through comments in the ebuild file, or through a `README.md`
+  in the folder.


### PR DESCRIPTION
The best practice established in this repository is to reset the
package	folder and import a new	version	from upstream without
modifications. In a separate commit the downstream changes are applied.
This makes it clear which downstream changes need to be	ported when
updating to a newer version in the future. Unfortunately this is not
always done which causes confusion and more work. As first step
document the process before we later look into more automation.

# How to use

Follow the guide when updating a package

# Testing done

Ran the `update_ebuilds` command.