### PR TITLE
sys-kernel/coreos-sources: fix vdso32 build for arm

### DIFF
--- a/sys-kernel/coreos-sources/coreos-sources-5.4.61.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-5.4.61.ebuild
@@ -36,4 +36,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
 	${PATCH_DIR}/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch \
 	${PATCH_DIR}/z0004-add-wireguard-module.patch \
+	${PATCH_DIR}/z0005-fix-vdso32-for-arm.patch \
 "

--- a/sys-kernel/coreos-sources/files/5.4/z0005-fix-vdso32-for-arm.patch
+++ b/sys-kernel/coreos-sources/files/5.4/z0005-fix-vdso32-for-arm.patch
@@ -1,0 +1,34 @@
+From: Frank van der Linden <fllinden@amazon.com>
+To: <linux-arm-kernel@lists.infradead.org>,
+	<linux-kernel@vger.kernel.org>, <catalin.marinas@arm.com>,
+	<will@kernel.org>
+Cc: Frank van der Linden <fllinden@amazon.com>
+Subject: [PATCH] arm64: vdso32: make vdso32 install conditional
+Date: Thu, 27 Aug 2020 23:40:12 +0000
+Message-ID: <20200827234012.19757-1-fllinden@amazon.com> (raw)
+
+vdso32 should only be installed if CONFIG_COMPAT_VDSO is enabled,
+since it's not even supposed to be compiled otherwise, and arm64
+builds without a 32bit crosscompiler will fail.
+
+Signed-off-by: Frank van der Linden <fllinden@amazon.com>
+Fixes: 8d75785a8142 ("ARM64: vdso32: Install vdso32 from vdso_install")
+Cc: stable@vger.kernel.org [5.4+]
+---
+ arch/arm64/Makefile | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
+index b45f0124cc16..100abbb19e0b 100644
+--- a/arch/arm64/Makefile
++++ b/arch/arm64/Makefile
+@@ -165,7 +165,8 @@ zinstall install:
+ PHONY += vdso_install
+ vdso_install:
+ 	$(Q)$(MAKE) $(build)=arch/arm64/kernel/vdso $@
+-	$(Q)$(MAKE) $(build)=arch/arm64/kernel/vdso32 $@
++	$(if $(CONFIG_COMPAT_VDSO),$(Q)$(MAKE) \
++		$(build)=arch/arm64/kernel/vdso32 $@)
+ 
+ # We use MRPROPER_FILES and CLEAN_FILES now
+ archclean:


### PR DESCRIPTION
This change adds a [kernel 5.9 upstream patch](https://lore.kernel.org/linux-arm-kernel/20200827234012.19757-1-fllinden@amazon.com/)  which fixes a vdso build error on ARM:

```
gcc: error: unrecognized argument in option ‘-mabi=aapcs-linux’
gcc: note: valid arguments to ‘-mabi=’ are: ms sysv
gcc: error: unrecognized argument in option ‘-mabi=aapcs-linux’
gcc: note: valid arguments to ‘-mabi=’ are: ms sysv
gcc: error: unrecognized argument in option ‘-mabi=aapcs-linux’
gcc: note: valid arguments to ‘-mabi=’ are: ms sysv
gcc: error: unrecognized command line option ‘-mfloat-abi=soft’
gcc: error: unrecognized command line option ‘-mfloat-abi=soft’
gcc: error: unrecognized command line option ‘-mfloat-abi=soft’
gcc: error: unrecognized command line option ‘-mlittle-endian’; did you mean ‘-fconvert=little-endian’?
```
### Also cherry-pick to `flatcar-2605` and include in `alpha-2605.1.0`
