### PR TITLE
sys-kernel: Include patch for overflow in tpacket_rcv

### DIFF
--- a/sys-kernel/coreos-sources/coreos-sources-5.4.62.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-5.4.62.ebuild
@@ -36,4 +36,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
 	${PATCH_DIR}/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch \
 	${PATCH_DIR}/z0004-add-wireguard-module.patch \
+	${PATCH_DIR}/z0005-net_packet_fix_overflow_in_tpacket_rcv_patch.patch \
 "

--- a/sys-kernel/coreos-sources/files/5.4/z0005-net_packet_fix_overflow_in_tpacket_rcv_patch.patch
+++ b/sys-kernel/coreos-sources/files/5.4/z0005-net_packet_fix_overflow_in_tpacket_rcv_patch.patch
@@ -1,0 +1,50 @@
+From 3ad04c9555b93ac6a374b0921ad41849caf22067 Mon Sep 17 00:00:00 2001
+From: Or Cohen <orcohen@paloaltonetworks.com>
+Date: Sun, 30 Aug 2020 20:04:51 +0300
+Subject: [PATCH] net/packet: fix overflow in tpacket_rcv
+
+Using tp_reserve to calculate netoff can overflow as
+tp_reserve is unsigned int and netoff is unsigned short.
+
+This may lead to macoff receving a smaller value then
+sizeof(struct virtio_net_hdr), and if po->has_vnet_hdr
+is set, an out-of-bounds write will occur when
+calling virtio_net_hdr_from_skb.
+
+The bug is fixed by converting netoff to unsigned int
+and checking if it exceeds USHRT_MAX.
+
+Fixes: 8913336a7e8d ("packet: add PACKET_RESERVE sockopt")
+Signed-off-by: Or Cohen <orcohen@paloaltonetworks.com>
+---
+ net/packet/af_packet.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/net/packet/af_packet.c b/net/packet/af_packet.c
+index 29bd405adbbd..d37435906859 100644
+--- a/net/packet/af_packet.c
++++ b/net/packet/af_packet.c
+@@ -2168,7 +2168,8 @@ static int tpacket_rcv(struct sk_buff *skb, struct net_device *dev,
+ 	int skb_len = skb->len;
+ 	unsigned int snaplen, res;
+ 	unsigned long status = TP_STATUS_USER;
+-	unsigned short macoff, netoff, hdrlen;
++	unsigned short macoff, hdrlen;
++	unsigned int netoff;
+ 	struct sk_buff *copy_skb = NULL;
+ 	struct timespec64 ts;
+ 	__u32 ts_status;
+@@ -2237,6 +2238,10 @@ static int tpacket_rcv(struct sk_buff *skb, struct net_device *dev,
+ 		}
+ 		macoff = netoff - maclen;
+ 	}
++	if (netoff > USHRT_MAX) {
++		atomic_inc(&po->tp_drops);
++		goto drop_n_restore;
++	}
+ 	if (po->tp_version <= TPACKET_V2) {
+ 		if (macoff + snaplen > po->rx_ring.frame_size) {
+ 			if (po->copy_thresh &&
+-- 
+2.17.1
+


### PR DESCRIPTION
A memory corruption vulnerability in AF_PACKET causes the kernel to
    panic or enter undefined behavior, tracked as CVE-2020-14386.
    While the proposed patch is not included in an upstream release,
    include it as downstream patch.
    Further information and PoC:
    https://www.openwall.com/lists/oss-security/2020/09/03/3

**Note:** Will be picked for _main_.

# How to use

A PoC was published on oss-security.

# Testing done

The PoC does not trigger a panic.