### PR TITLE
sys-kernel: Include patch for overflow in tpacket_rcv

### DIFF
--- a/sys-kernel/coreos-sources/coreos-sources-4.19.143.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.19.143.ebuild
@@ -35,4 +35,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
 	${PATCH_DIR}/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch \
+	${PATCH_DIR}/z0004_net_packet_fix_overflow_in_tpacket_rcv-4.9.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.19/z0004_net_packet_fix_overflow_in_tpacket_rcv-4.9.patch
+++ b/sys-kernel/coreos-sources/files/4.19/z0004_net_packet_fix_overflow_in_tpacket_rcv-4.9.patch
@@ -1,0 +1,58 @@
+From: Or Cohen <orco...@paloaltonetworks.com>
+
+Using tp_reserve to calculate netoff can overflow as
+tp_reserve is unsigned int and netoff is unsigned short.
+
+This may lead to macoff receving a smaller value then
+sizeof(struct virtio_net_hdr), and if po->has_vnet_hdr
+is set, an out-of-bounds write will occur when
+calling virtio_net_hdr_from_skb.
+
+The bug is fixed by converting netoff to unsigned int
+and checking if it exceeds USHRT_MAX.
+
+This addresses CVE-2020-14386
+
+Fixes: 8913336a7e8d ("packet: add PACKET_RESERVE sockopt")
+Signed-off-by: Or Cohen <orco...@paloaltonetworks.com>
+Signed-off-by: Eric Dumazet <eduma...@google.com>
+
+[ snu: backported to 4.9, changed tp_drops counting/locking ]
+
+Signed-off-by: Stefan Nuernberger <s...@amazon.com>
+CC: David Woodhouse <d...@amazon.co.uk>
+CC: Amit Shah <a...@amazon.com>
+CC: sta...@vger.kernel.org
+---
+ net/packet/af_packet.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/net/packet/af_packet.c b/net/packet/af_packet.c
+index fb643945e424..b5b79f501541 100644
+--- a/net/packet/af_packet.c
++++ b/net/packet/af_packet.c
+@@ -2161,7 +2161,8 @@ static int tpacket_rcv(struct sk_buff *skb, struct net_device *dev,
+	int skb_len = skb->len;
+	unsigned int snaplen, res;
+	unsigned long status = TP_STATUS_USER;
+-	unsigned short macoff, netoff, hdrlen;
++	unsigned short macoff, hdrlen;
++	unsigned int netoff;
+	struct sk_buff *copy_skb = NULL;
+	struct timespec ts;
+	__u32 ts_status;
+@@ -2223,6 +2224,12 @@ static int tpacket_rcv(struct sk_buff *skb, struct net_device *dev,
+		}
+		macoff = netoff - maclen;
+	}
++	if (netoff > USHRT_MAX) {
++		spin_lock(&sk->sk_receive_queue.lock);
++		po->stats.stats1.tp_drops++;
++		spin_unlock(&sk->sk_receive_queue.lock);
++		goto drop_n_restore;
++	}
+	if (po->tp_version <= TPACKET_V2) {
+		if (macoff + snaplen > po->rx_ring.frame_size) {
+			if (po->copy_thresh &&
+-- 
+2.28.0


### PR DESCRIPTION
A memory corruption vulnerability in AF_PACKET causes the kernel to panic or enter undefined behavior, tracked as CVE-2020-14386. While the proposed patch is not included in an upstream release, include it as downstream patch.

Further information and PoC:
https://www.openwall.com/lists/oss-security/2020/09/03/3
Snu's backport to 4.x:
https://www.mail-archive.com/netdev@vger.kernel.org/msg351203.html

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>

# Testing done
- reproduced kernel crash in QEmu using PoC
- built kernel locally in 2512.3.0 SDK, w/ patch applied
- could not reproduce kernel crash with patch applied
