### PR TITLE
.github: fix regexp to get correct semver from Go ebuilds

### DIFF
--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -15,7 +15,10 @@ fi
 
 pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
 
-VERSION_OLD=$(sed -n "s/^DIST go\(${VERSION_SHORT}.[0-9]*\).*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
+# Parse the Manifest file for already present source files and keep the latest version in the current series
+# DIST go1.15.src.tar.gz ... => 1.15
+# DIST go1.15.3.src.tar.gz ... => 1.15.3
+VERSION_OLD=$(sed -n "s/^DIST go\(${VERSION_SHORT}\.*[0-9]*\)\.src.*/\1/p" dev-lang/go/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   echo "already the latest Go, nothing to do"
   UPDATE_NEEDED=0


### PR DESCRIPTION
Github Action for Go has had a bug when parsing the current Go version from `dev-lang/go/Manifest`, only when the current ebuild file has only major + minor versions, without patchlevel.
For example, it could parse well `1.13.15`, but not `1.15`.
We need to make it deal with both versions, `x.y.z` and `x.y`.

With this PR, for example, when `VERSION_SHORT` is `1.15` and the Manifest includes a tarball `go1.15.src.tar.gz`, we can confirm the new regexp works well like below:

```
$ sed -n "s/^DIST go\(1.15.*[0-9]*\)\.src.*/\1/p" dev-lang/go/Manifest
1.15
```
