### PR TITLE
sys-kernel/coreos-sources: Regenerate the patches against 5.8.9

### DIFF
--- a/sys-kernel/coreos-sources/coreos-sources-5.8.9.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-5.8.9.ebuild
@@ -32,7 +32,7 @@ IUSE=""
 # patchlevel revision.  We mustn't apply our patches first, it fails when the
 # local patches overlap with the upstream patch.
 UNIPATCH_LIST="
-	${PATCH_DIR}/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
+	${PATCH_DIR}/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch \
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
 	${PATCH_DIR}/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch \
 "

--- a/sys-kernel/coreos-sources/files/5.8/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch
+++ b/sys-kernel/coreos-sources/files/5.8/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch
@@ -1,4 +1,4 @@
-From 7cf237ffad0402d65f56dd694285988c519a01e2 Mon Sep 17 00:00:00 2001
+From b500ac62a04f6aede02e0ca8c9a4228b0ffc2828 Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
 Subject: [PATCH 1/3] kbuild: derive relative path for srctree from CURDIR
@@ -8,14 +8,14 @@ provided they stay reachable relative to one another.  Useful for
 builds done within a sandbox where the eventual root is prefixed
 by some undesirable path component.
 ---
- Makefile | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 4d29c7370b46..a04c9783adac 100644
+index 36eab48d1d4a..0514c0fa114d 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -143,7 +143,7 @@ $(filter-out _all sub-make $(CURDIR)/Makefile, $(MAKECMDGOALS)) _all: sub-make
+@@ -240,7 +240,7 @@ else
  endif
  
  ifneq ($(KBUILD_ABS_SRCTREE),)
@@ -25,5 +25,5 @@ index 4d29c7370b46..a04c9783adac 100644
  
  objtree		:= .
 -- 
-2.21.0
+2.26.2
 

--- a/sys-kernel/coreos-sources/files/5.8/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
+++ b/sys-kernel/coreos-sources/files/5.8/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
@@ -1,4 +1,4 @@
-From fa65e1abfe64b43cef645d1a20fe763c1e85e49d Mon Sep 17 00:00:00 2001
+From d2559ba1a806f8d010d09807c2c0906181824626 Mon Sep 17 00:00:00 2001
 From: David Michael <david.michael@coreos.com>
 Date: Thu, 8 Feb 2018 21:23:12 -0500
 Subject: [PATCH 2/3] tools/objtool/Makefile: Don't fail on fallthrough with
@@ -9,10 +9,10 @@ Subject: [PATCH 2/3] tools/objtool/Makefile: Don't fail on fallthrough with
  1 file changed, 3 insertions(+)
 
 diff --git a/tools/lib/subcmd/Makefile b/tools/lib/subcmd/Makefile
-index 5b2cd5e58df0..cb255e5ad545 100644
+index 1c777a72bb39..0217b7af786a 100644
 --- a/tools/lib/subcmd/Makefile
 +++ b/tools/lib/subcmd/Makefile
-@@ -39,6 +39,9 @@ ifneq ($(WERROR),0)
+@@ -40,6 +40,9 @@ ifneq ($(WERROR),0)
    CFLAGS += -Werror
  endif
  
@@ -23,5 +23,5 @@ index 5b2cd5e58df0..cb255e5ad545 100644
  
  CFLAGS += -I$(srctree)/tools/include/
 -- 
-2.21.0
+2.26.2
 

--- a/sys-kernel/coreos-sources/files/5.8/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch
+++ b/sys-kernel/coreos-sources/files/5.8/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch
@@ -1,4 +1,4 @@
-From 9b647a6c58075abfdefa803c76ea34eeaad6dd42 Mon Sep 17 00:00:00 2001
+From ab2e2914cd297cd14a82fdbe6b709290bd9fe449 Mon Sep 17 00:00:00 2001
 From: Benjamin Gilbert <bgilbert@redhat.com>
 Date: Fri, 26 Oct 2018 17:00:56 -0700
 Subject: [PATCH 3/3] net/netfilter: add nf_conntrack_ipv4 compat module for
@@ -15,10 +15,10 @@ enough to maintain compatibility; we need an actual module.
  create mode 100644 net/netfilter/nf_conntrack_ipv4.c
 
 diff --git a/net/netfilter/Kconfig b/net/netfilter/Kconfig
-index e0fb56d67d42..a468ee1de6fe 100644
+index 0ffe2b8723c4..522b1a6c9e7e 100644
 --- a/net/netfilter/Kconfig
 +++ b/net/netfilter/Kconfig
-@@ -70,6 +70,14 @@ config NF_CONNTRACK
+@@ -71,6 +71,14 @@ config NF_CONNTRACK
  
  	  To compile it as a module, choose M here.  If unsure, say N.
  
@@ -34,17 +34,17 @@ index e0fb56d67d42..a468ee1de6fe 100644
  	tristate
  
 diff --git a/net/netfilter/Makefile b/net/netfilter/Makefile
-index 16895e045b66..24d8da425ed8 100644
+index 0e0ded87e27b..fb28e546187b 100644
 --- a/net/netfilter/Makefile
 +++ b/net/netfilter/Makefile
-@@ -24,6 +24,7 @@ obj-$(CONFIG_NETFILTER_NETLINK_OSF) += nfnetlink_osf.o
+@@ -25,6 +25,7 @@ obj-$(CONFIG_NETFILTER_NETLINK_OSF) += nfnetlink_osf.o
  
  # connection tracking
  obj-$(CONFIG_NF_CONNTRACK) += nf_conntrack.o
 +obj-$(CONFIG_NF_CONNTRACK_IPV4_COMPAT) += nf_conntrack_ipv4.o
  
- obj-$(CONFIG_NF_CT_PROTO_GRE) += nf_conntrack_proto_gre.o
- 
+ # netlink interface for nf_conntrack
+ obj-$(CONFIG_NF_CT_NETLINK) += nf_conntrack_netlink.o
 diff --git a/net/netfilter/nf_conntrack_ipv4.c b/net/netfilter/nf_conntrack_ipv4.c
 new file mode 100644
 index 000000000000..8308772022c6
@@ -83,5 +83,5 @@ index 000000000000..8308772022c6
 +MODULE_DESCRIPTION("kube-proxy compatibility wrapper for nf_conntrack.ko");
 +MODULE_LICENSE("GPL");
 -- 
-2.21.0
+2.26.2
 


### PR DESCRIPTION
These used to apply just fine with the `patch` utility, but `git am` was complaining (when creating the `v5.8.8-flatcar` branch for our linux repo):

```
$ git am ../coreos-overlay/main/sys-kernel/coreos-sources/files/5.8/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch
Applying: net/netfilter: add nf_conntrack_ipv4 compat module for kube-proxy
error: patch failed: net/netfilter/Makefile:24
error: net/netfilter/Makefile: patch does not apply
Patch failed at 0001 net/netfilter: add nf_conntrack_ipv4 compat module for kube-proxy
hint: Use 'git am --show-current-patch=diff' to see the failed patch
When you have resolved this problem, run "git am --continue".
If you prefer to skip this patch, run "git am --skip" instead.
To restore the original branch and stop patching, run "git am --abort".
```

I think it was mostly the context didn't match any more.