### PR TITLE
profile: adjust profiles for jq, rsync

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -23,9 +23,10 @@ dev-util/checkbashisms
 # Older versions of sssd fail to build
 =sys-auth/sssd-1.13.1 ~amd64 ~arm64
 
-# heap overflow fix
+# jq 1.5-r2 for heap overflow fix
 # https://bugs.gentoo.org/show_bug.cgi?id=580606
-=app-misc/jq-1.5-r2 ~amd64 ~arm64
+# jq 1.6-r3 for CVE-2015-8863
+>=app-misc/jq-1.5-r2 ~amd64 ~arm64
 
 # Must use the same version across all architectures
 =dev-libs/protobuf-2.6.1-r3

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -102,3 +102,6 @@ sys-fs/btrfs-progs -zstd
 
 # enable regular expression processing in jq
 app-misc/jq oniguruma
+
+# Disable sse2 from CPU_FLAGS_X86 to avoid config error around simd
+net-misc/rsync -cpu_flags_x86_sse2


### PR DESCRIPTION
Adjust profiles for `app-misc/jq` and `net-misc/rsync`, to correctly build the corresponding [PR](https://github.com/flatcar-linux/portage-stable/pull/104).

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/104.

## How to use

```
./build_packages
```

## Testing done

TBD