### PR TITLE
profiles: adjust to clean up serf, apr-util

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -44,7 +44,6 @@
 =net-libs/libnetfilter_queue-1.0.3 ~arm64
 =net-libs/libnfnetlink-1.0.1 ~arm64
 =net-libs/libnftnl-1.0.6 **
-=net-libs/serf-1.3.8-r1 ~arm64
 =net-misc/bridge-utils-1.5 ~arm64
 =net-misc/iperf-3.1.3 **
 =net-misc/socat-1.7.3.2 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -10,7 +10,6 @@
 =dev-cpp/glog-0.3.4-r1 ~arm64
 =dev-lang/perl-5.24.1-r2 ~arm64
 =dev-lang/swig-3.0.12 ~arm64
-=dev-libs/apr-util-1.5.4-r1 ~arm64
 =dev-libs/ding-libs-0.4.0 **
 =dev-libs/elfutils-0.169-r1 ~arm64
 =dev-libs/libassuan-2.5.1 ~arm64

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -31,7 +31,6 @@ dev-util/glib-utils python_single_target_python3_6
 sys-apps/gptfdisk -icu
 
 # for profile migration
-dev-libs/apr-util -gdbm
 sys-libs/gdbm berkdb
 
 dev-vcs/git -pcre-jit -perl -iconv


### PR DESCRIPTION
Now that we cleaned up packages `net-libs/serf` and `dev-libs/apr-util`, we should also remove them from profiles.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/106.

## How to use

```
./build_packages
```

## Testing done

Jenkins Ci passed