### PR TITLE
Switch to our new mirrors

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -48,8 +48,8 @@ ACCEPT_LICENSE="* -@EULA -@CHROMEOS"
 
 # Favor our own mirrors over Gentoo's
 GENTOO_MIRRORS="
-    https://storage.core-os.net/mirror/portage-stable/
-    https://storage.core-os.net/mirror/coreos/
+    https://mirror.release.flatcar-linux.net/portage-stable/
+    https://mirror.release.flatcar-linux.net/coreos/
     http://distfiles.gentoo.org/
 "
 


### PR DESCRIPTION
We've created flatcar mirrors to stop depending on coreos mirrors. This change switches to those mirrors instead of the deprecated coreos ones.

I've verified that the SDK job picked up this change when building from this branch.

This will need to be cherry picked to all active branches.

Needed for: kinvolk/PROJECT-flatcar-linux#333