### PR TITLE
coreos-base/coreos: Build and install oslogin for amd64 only

### DIFF
--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -173,5 +173,7 @@ RDEPEND="${RDEPEND}
 
 # OEM specific bits that need to go in USR
 RDEPEND+="
-	sys-auth/google-oslogin
+	amd64? (
+		sys-auth/google-oslogin
+	)
 "


### PR DESCRIPTION
The build for arm64 currently fails because it tries to build the
oslogin package but the package is marked as amd64-only.
Exclude the oslogin package from arm64 images.

# How to use

Build an arm64 image.

# Testing done

None yet