### PR TITLE
Enable remote-fs

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -433,6 +433,12 @@ multilib_src_install_all() {
 	# Flatcar: getty@.service is enabled manually below.
 	systemd_enable_service sysinit.target systemd-timesyncd.service
 	systemd_enable_service multi-user.target systemd-networkd.service
+	# For systemd-networkd.service, it has it in Also, which also
+	# needs to be enabled
+	systemd_enable_service sockets.target systemd-networkd.socket
+	# For systemd-networkd.service, it has it in Also, which also
+	# needs to be enabled
+	systemd_enable_service network-online.target systemd-networkd-wait-online.service
 	systemd_enable_service multi-user.target systemd-resolved.service
 	# Flatcar: not enabling reboot.target - it has no WantedBy
 	# entry.

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -426,14 +426,15 @@ multilib_src_install_all() {
 	# Flatcar: Don't enable services in /etc, move to /usr.
 	systemd_enable_service multi-user.target systemd-networkd.service
 	systemd_enable_service multi-user.target systemd-resolved.service
+	systemd_enable_service multi-user.target remote-fs.target
 	systemd_enable_service sysinit.target systemd-timesyncd.service
 
 	# Flatcar: Enable getty manually.
 	mkdir --parents "${ED}/usr/lib/systemd/system/getty.target.wants"
 	dosym ../getty@.service "/usr/lib/systemd/system/getty.target.wants/getty@tty1.service"
 
-	# Flatcar: Do not enable random services if /etc was detected
-	# as empty!!!
+	# Flatcar: Use an empty preset file, because systemctl
+	# preset-all puts symlinks in /etc, not in /usr.
 	rm "${ED}$(usex split-usr '' /usr)/lib/systemd/system-preset/90-systemd.preset" || die
 	insinto $(usex split-usr '' /usr)/lib/systemd/system-preset
 	doins "${FILESDIR}"/99-default.preset

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -423,11 +423,20 @@ multilib_src_install_all() {
 	# Flatcar: Don't set any extra environment variables by default.
 	rm "${ED}/usr/lib/environment.d/99-environment.conf" || die
 
-	# Flatcar: Don't enable services in /etc, move to /usr.
+	# Flatcar: These lines more or less follow the systemd's
+	# preset file (90-systemd.preset). We do it that way, to avoid
+	# putting symlink in /etc. Please keep the lines in the same
+	# order as the "enable" lines appear in the preset file.
+	systemd_enable_service multi-user.target remote-fs.target
+	systemd_enable_service multi-user.target remote-cryptsetup.target
+	systemd_enable_service multi-user.target machines.target
+	# Flatcar: getty@.service is enabled manually below.
+	systemd_enable_service sysinit.target systemd-timesyncd.service
 	systemd_enable_service multi-user.target systemd-networkd.service
 	systemd_enable_service multi-user.target systemd-resolved.service
-	systemd_enable_service multi-user.target remote-fs.target
-	systemd_enable_service sysinit.target systemd-timesyncd.service
+	# Flatcar: not enabling reboot.target - it has no WantedBy
+	# entry.
+	systemd_enable_service remount-fs.target systemd-pstore.service
 
 	# Flatcar: Enable getty manually.
 	mkdir --parents "${ED}/usr/lib/systemd/system/getty.target.wants"

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -443,7 +443,8 @@ multilib_src_install_all() {
 	dosym ../getty@.service "/usr/lib/systemd/system/getty.target.wants/getty@tty1.service"
 
 	# Flatcar: Use an empty preset file, because systemctl
-	# preset-all puts symlinks in /etc, not in /usr.
+	# preset-all puts symlinks in /etc, not in /usr. We don't use
+	# /etc, because it is not autoupdated. We do the "preset" above.
 	rm "${ED}$(usex split-usr '' /usr)/lib/systemd/system-preset/90-systemd.preset" || die
 	insinto $(usex split-usr '' /usr)/lib/systemd/system-preset
 	doins "${FILESDIR}"/99-default.preset


### PR DESCRIPTION
Since v242 remote-fs.target was not enabled by default, so mounting NFS shares did not happen after the update from 2512 (which has systemd 241). The ebuild was enabling remote-fs though, by putting a symlink in `/etc/systemd/system/…`. But this change in `/etc/ is apparently propagated during update, so remote-fs.target ended up being not a dependent target during boot. So the PR tries harder at not enabling services through /etc, but through /lib.


# How to use

[ describe what reviewers need to do in order to validate this PR ]


# Testing done

The image is building for me at the moment, but:

```
find /build/amd64-usr/usr/lib/systemd/ | grep 'remote-fs'
/build/amd64-usr/usr/lib/systemd/system/remote-fs.target
/build/amd64-usr/usr/lib/systemd/system/remote-fs-pre.target
/build/amd64-usr/usr/lib/systemd/system/multi-user.target.wants/remote-fs.target # that used to be missing
/build/amd64-usr/usr/lib/systemd/system/remote-fs.target.wants
/build/amd64-usr/usr/lib/systemd/system/remote-fs.target.wants/var-lib-machines.mount
```

(in comparison with current stable)

```
Flatcar Container Linux by Kinvolk stable (2605.5.0)
core@localhost ~ $ find /usr/lib/systemd/ | grep remote-fs
/usr/lib/systemd/system/remote-fs.target.wants
/usr/lib/systemd/system/remote-fs.target.wants/var-lib-machines.mount
/usr/lib/systemd/system/remote-fs-pre.target
/usr/lib/systemd/system/remote-fs.target
```

Fixes flatcar-linux/Flatcar#191

To be propagated to flatcar-2605 and flatcar-2632.