### PR TITLE
sys-kernel/coreos-firmware: Disable savedconfig flag and file creation

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -104,3 +104,6 @@ app-misc/jq oniguruma
 
 # Disable sse2 from CPU_FLAGS_X86 to avoid config error around simd
 net-misc/rsync -cpu_flags_x86_sse2
+
+# Don't read the firmware config from /etc/portage/savedconfig/
+sys-kernel/coreos-firmware -savedconfig

--- a/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
+++ b/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
@@ -166,9 +166,10 @@ src_prepare() {
 }
 
 src_install() {
-	if use !savedconfig; then
-		save_config ${PN}.conf
-	fi
+	# Flatcar: Don't save the firmware config to /etc/portage/savedconfig/
+	# if use !savedconfig; then
+	# 	save_config ${PN}.conf
+	# fi
 	rm ${PN}.conf || die
 	insinto /lib/firmware/
 	doins -r *


### PR DESCRIPTION
The savedconfig feature reads and, if not set, generates a file under
    /etc/portage/savedconfig/ to source a build configuration. We probably
    don't want this and specially not on the final image, therefore,
    disable reading and also don't write the file to the final image.

**Note:** Pick for 2605, 2632, and 2643

# How to use

Build an image and check if `/etc/portage` exists which it shouldn't.

# Testing done

Built an image and saw that the file is gone.