### PR TITLE
Update srctree path to correctly populate Makefile

### DIFF
--- a/sys-kernel/coreos-sources/files/5.8/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch
+++ b/sys-kernel/coreos-sources/files/5.8/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch
@@ -15,15 +15,17 @@ diff --git a/Makefile b/Makefile
 index 36eab48d1d4a..0514c0fa114d 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -240,7 +240,7 @@ else
+@@ -230,9 +230,7 @@ else
+ 	building_out_of_srctree := 1
  endif
- 
- ifneq ($(KBUILD_ABS_SRCTREE),)
+
+-ifneq ($(KBUILD_ABS_SRCTREE),)
 -srctree := $(abs_srctree)
+-endif
 +srctree := $(shell realpath --relative-to=$(KBUILD_OUTPUT) $(abs_srctree))
- endif
- 
+
  objtree		:= .
--- 
+ VPATH		:= $(srctree)
+--
 2.26.2
 


### PR DESCRIPTION
Update srctree path to correctly populate the Makefile for sandbox
environments. The patch is to adjusted for 5.x kernels

Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# How to use / Testing done

Sayan ran a Jenkins job with this change and after running that, the image generated has this file:
```
core@localhost ~ $ cat /usr/lib64/modules/5.8.10-flatcar/build/Makefile 
# Automatically generated by ../source/scripts/mkmakefile: don't edit
include ../source/Makefile
```

Which is correct as it no longer includes the sandbox environment.

This change needs to be cherry-picked to flatcar-2605 and flatcar-2632
