### PR TITLE
Update libseccomp to 2.5.0

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -83,3 +83,5 @@ dev-util/checkbashisms
 =dev-lang/rust-1.46.0 ~amd64 ~arm64
 
 =sys-fs/cryptsetup-2.0.3 ~amd64
+
+=sys-libs/libseccomp-2.5.0 ~amd64 ~arm64


### PR DESCRIPTION
# Update libseccomp to 2.5.0

The ebuild is in the portage-stable repository but we need this patch in
coreos-overlay to avoid this error:
```
> The following keyword changes are necessary to proceed:
>  (see "package.accept_keywords" in the portage(5) man page for more details)
> # required by sys-apps/systemd-245-r3::coreos[seccomp]
> # required by app-misc/ca-certificates-3.27.1-r1::coreos
> # required by dev-libs/openssl-1.1.1g::coreos
> # required by net-misc/rsync-3.2.3::portage-stable[-libressl,ssl,-static]
> # required by sys-apps/portage-2.3.40-r1::coreos[-build]
> # required by app-admin/perl-cleaner-2.27::portage-stable
> # required by dev-lang/perl-5.26.2::portage-stable
> # required by sys-apps/help2man-1.45.1::portage-stable
> # required by sys-devel/automake-1.16.1-r1::portage-stable
> # required by dev-libs/libxml2-2.9.8::portage-stable
> # required by x11-misc/shared-mime-info-1.4::portage-stable
> # required by dev-libs/gobject-introspection-1.40.0-r1::portage-stable
> # required by sys-auth/polkit-0.113-r5::coreos[introspection]
> =sys-libs/libseccomp-2.5.0 ~amd64
```

# How to use

This PR should be used together with:
https://github.com/flatcar-linux/portage-stable/pull/111

# Testing done

I have not run any tests.