### PR TITLE
oem-qemu: Add OEM package for QEMU

### DIFF
--- a/coreos-base/oem-qemu/files/grub.cfg
+++ b/coreos-base/oem-qemu/files/grub.cfg
@@ -1,0 +1,4 @@
+# Flatcar GRUB settings
+
+set oem_id="qemu"
+set linux_append="flatcar.autologin"

--- a/coreos-base/oem-qemu/files/oem-release
+++ b/coreos-base/oem-qemu/files/oem-release
@@ -1,0 +1,5 @@
+ID=qemu
+VERSION_ID=@@OEM_VERSION_ID@@
+NAME="QEMU"
+HOME_URL="https://www.qemu.org/"
+BUG_REPORT_URL="https://issues.flatcar-linux.org"

--- a/coreos-base/oem-qemu/metadata.xml
+++ b/coreos-base/oem-qemu/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-qemu/oem-qemu-0.0.1.ebuild
+++ b/coreos-base/oem-qemu/oem-qemu-0.0.1.ebuild
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Kinvolk GmbH. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="OEM suite for QEMU"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 arm64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+src_prepare() {
+	sed -e "s\\@@OEM_VERSION_ID@@\\${PVR}\\g" \
+		"${FILESDIR}/oem-release" > "${T}/oem-release" || die
+}
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins "${FILESDIR}/grub.cfg"
+	doins "${T}/oem-release"
+}
+


### PR DESCRIPTION
# oem-qemu: Add OEM package for QEMU

Fix flatcar-linux/Flatcar#71

Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# How to use
```
emerge-amd64-usr oem-qemu
./build_image
./image_to_vm.sh --format=qemu
```


# Testing done

Built a local image, and created a QEMU image. Verified in `/usr/share/oem/{grub.cfg|oem-release}`
