### PR TITLE
Revert "sys-apps/systemd: Drop the resolv.conf workaround"

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -184,7 +184,10 @@ src_prepare() {
 	# This shouldn't be necessary anymore. Added because of a bug
 	# https://github.com/systemd/systemd/issues/3826, which is
 	# apparently resolved in
-	# https://github.com/systemd/systemd/pull/5276.
+	# https://github.com/systemd/systemd/pull/5276 but another reason is
+	# that when /etc/resolve.conf is bind-mounted to a new network
+	# namespace it shouldn't contain the loopback IP address of the host
+	# which is not reachable from another network namespace.
 	sed -i -e 's,/run/systemd/resolve/stub-resolv.conf,/run/systemd/resolve/resolv.conf,' tmpfiles.d/etc.conf.m4 || die
 
 	default

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -179,6 +179,14 @@ src_unpack() {
 
 src_prepare() {
 	# Flatcar: We don't have separate patches, so no patching code here.
+	#
+	# Flatcar: Use the resolv.conf managed by systemd-resolved.
+	# This shouldn't be necessary anymore. Added because of a bug
+	# https://github.com/systemd/systemd/issues/3826, which is
+	# apparently resolved in
+	# https://github.com/systemd/systemd/pull/5276.
+	sed -i -e 's,/run/systemd/resolve/stub-resolv.conf,/run/systemd/resolve/resolv.conf,' tmpfiles.d/etc.conf.m4 || die
+
 	default
 }
 


### PR DESCRIPTION
This reverts commit c414b38c7c56dafb05a86040443c634763527f05.
The real DNS server IP addresses should be in /etc/resolve.conf and not
just 127.0.0.53 because all cases that bind-mount /etc/resolve.conf
into a new network namespace can't reach the loopback interface that
resolved is listening on.

# How to use



# Testing done

None