### PR TITLE
sys-apps/baselayout: Ensure to create core home folder in the SDK

### DIFF
--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -115,8 +115,14 @@ src_install() {
 	done
 
 	if use cros_host; then
-		# We assume that SDK already has the user and group database.
-		:
+		# Since later systemd-tmpfiles --root is used only users from
+		# /etc/passwd are considered but we don't want to add core there
+		# because it would make emerge overwrite the system's database on
+		# installation when the SDK user is already there. Instead, just
+		# create the folder manually and remove the tmpfile directive.
+		rm "${S}/tmpfiles.d/baselayout-home.conf"
+		mkdir -p "${D}"/home/core
+		chown 500:500 "${D}"/home/core
 	else
 		# Initialize /etc/passwd, group, and friends now, so
 		# systemd-tmpfiles can resolve user information in ${D}


### PR DESCRIPTION
Because the --root option restricts systemd-tmpfiles to the passwd
database file in the package chroot it can't resolve the core user
and fails to set up the home folder from the baselayout-home.conf
directives.
Create the folder manually because creating a /etc/passwd file in
the package chroot would at installation overwrite the SDK user.

# How to use

Run toolchains or SDK builds on Jenkins.

# Testing done

With the `2020.10.12+dev-flatcar-master-1196` SDK I was able to start builds.