### PR TITLE
sys-apps/baselayout, coreos-base/coreos-init: Point to lastest state

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="06c1731dabef7a68bd3542f5cc5379580b7c3931" # flatcar-master
+	CROS_WORKON_COMMIT="195216366d7c3a63db4bea6e8bf84e6c14cf11fd" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="df037edbeab79c38caed61f48dec7a00e764e20e" # flatcar-master
+	CROS_WORKON_COMMIT="84e618bef1a21ef943c87040dc8f2152f0961867" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/init/pull/28 and
https://github.com/flatcar-linux/baselayout/pull/7
to ensure that the /etc/coreos to /etc/flatcar symlink always exists.

Fixes https://github.com/flatcar-linux/Flatcar/issues/190

*Note:* This will be included in all maintenance branches. In case of Stable this pulls in two harmless additional changes that won't affect behavior:
https://github.com/flatcar-linux/baselayout/pull/6
https://github.com/flatcar-linux/init/pull/27

# How to use

See https://github.com/flatcar-linux/baselayout/pull/7

# Testing done

Tested with the `main` branch.