### PR TITLE
coreos-base/coreos: Add diffutils to the base packages

### DIFF
--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -135,6 +135,7 @@ RDEPEND="${RDEPEND}
 	net-vpn/wireguard-tools
 	sys-apps/coreutils
 	sys-apps/dbus
+	sys-apps/diffutils
 	sys-apps/ethtool
 	sys-apps/findutils
 	sys-apps/gawk


### PR DESCRIPTION
The diffutils package provides the "cmp" and "diff" tools which are
essential commands in shell scripts. They used to be pulled in by
audit but the update in
https://github.com/flatcar-linux/coreos-overlay/pull/537
caused them to be dropped.
Add them to the explicit list of base packages to ensure they are
installed.

**Note:** Will be picked to `flatcar-2661`

# How to use

The final image should have the `cmp` and `diff` commands (and friends like `diff3` or `sdiff`).

# Testing done

None