### PR TITLE
coreos-base/coreos-init, sys-kernel/bootengine: Update to latest state

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="195216366d7c3a63db4bea6e8bf84e6c14cf11fd" # flatcar-master
+	CROS_WORKON_COMMIT="e56e0c1f2174598c03ffedb26a8530849beef664" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="acfe1b9b78c5596a00693a57ddaafb9d13e1019e" # flatcar-master
+	CROS_WORKON_COMMIT="fa5979f7c847a786d020df5c6a01efc1f2d57f54" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/bootengine/pull/19
and https://github.com/flatcar-linux/init/pull/29
to exclude the bonded interface from networkd in Azure.

**Note:** May have to be picked to all branches, but I didn't verify if the current Stable is affected. Thus, just including it in 2661 for now.

# How to use

Boot a machine as see if the systemd-networkd-wait-online.service failed.

# Testing done

[Built an image](http://localhost:9091/job/os/job/manifest/1216/console), all [tests passing](http://localhost:9091/job/os/job/kola/job/azure/194/console)