### PR TITLE
coreos-base/afterburn: Point to latest commit

### DIFF
--- a/coreos-base/afterburn/afterburn-9999.ebuild
+++ b/coreos-base/afterburn/afterburn-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="git://github.com"
 if [[ ${PV} == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="c9d380dbb868bf46833c08378f35048666f7c404" # flatcar-master
+	CROS_WORKON_COMMIT="be818b9769ac615ad0a44f380ef4773f37edece8" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/afterburn/pull/10
to fix systemd-networkd-wait-online on Equinix Metal (fka Packet).

**Note:** Include in `flatcar-2661`

# How to use

Running the kola tests suite should not give errors like this anymore:
```
failed basic checks: some systemd units failed:\n● systemd-networkd-wait-online.service loaded failed
```

# Testing done

[Here](http://localhost:9091/job/os/job/manifest/1223/cldsv/), looks good for t1.small, c2.medium, and c3.medium, but on the c3.small networkd sometimes has the bond0 interface stuck in `configuring` even though it is `routable` already - this goes away when restarting networkd and it looks like it is not robust enough for a corner case. We should probably report this as upstream bug.