### PR TITLE
profiles: gdbus-codegen only for python 3.6

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -26,6 +26,7 @@ dev-python/uritemplate -python_targets_python3_6
 sys-apps/portage -python_targets_python3_6
 
 # python3 only
+dev-util/gdbus-codegen python_single_target_python3_6
 dev-util/glib-utils python_single_target_python3_6
 
 sys-apps/gptfdisk -icu


### PR DESCRIPTION
To be able to update `dev-util/gdbus-codegen` to 2.64.5, we need to
specify a single target python3.6 for gdbus-codegen.

Without it, emerge gdbus-codegen 2.64.5 is not possible, because
it recognizes there are multiple python single targets.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/115 .

## Testing done

TBD