### PR TITLE
.github: Remove fetching unused key from gpg server

### DIFF
--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 CORK_VERSION=$(curl -s https://api.github.com/repos/flatcar-linux/mantle/releases/latest | jq -r .tag_name | sed -e 's/^v//')
 curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64
 curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64.sig
-gpg --keyserver keys.gnupg.net --receive-keys 84C8E771C0DF83DFBFCAAAF03ADA89DEC2507883
 curl -LO https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
 gpg --import Flatcar_Image_Signing_Key.asc
 gpg --verify cork.sig cork


### PR DESCRIPTION
The key server currently doesn't work. Since the key is not used
currently but the key we have hosted on our web server, we can remove
this failing step to restore GitHub Actions.

# How to use

Rerun GitHub Actions

# Testing done

Ran the commands to verify the cork binary.