### PR TITLE
upgrade coreos profile 17.1

### DIFF
--- a/profiles/coreos/amd64/parent
+++ b/profiles/coreos/amd64/parent
@@ -1,2 +1,2 @@
-portage-stable:default/linux/amd64/17.0/no-multilib/hardened
+portage-stable:default/linux/amd64/17.1/no-multilib/hardened
 :coreos/base


### PR DESCRIPTION
# upgrade coreos profile to 17.1

This upgrades the coreos profile to depend on Gentoo 17.1. The 17.0 profiles have been deprecated some time ago. The only difference between 17.0. and 17.1 profiles is that `lib` no longer links to `lib64`. This is already not the case for arm64.

Fixes kinvolk/Flatcar#428
Requires kinvolk/flatcar-scripts#136
Requires kinvolk/flatcar-scripts#134

## How to use

Full bootstrap required. Starting from a 2920.0.0 SDK, stage1 needs to be brought up with the correct profile:
```
sudo ./bootstrap_sdk --stage1_overlay_ref jepio/upgrade-profile-17.1-backport-2920
```

## Testing done

SDK successfully bootstrapped. Will test the rest through CI.