### PR TITLE
profiles: Add binutils-2.37 to the accept_keywords

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -44,8 +44,8 @@ dev-util/checkbashisms
 
 # Upgrade to GCC 9.3.0 to support latest glibc builds
 =sys-devel/gcc-config-1.9.1 ~amd64 ~arm64
-=sys-devel/binutils-2.36.1-r1 ~amd64 ~arm64
-=sys-libs/binutils-libs-2.36.1-r1 ~amd64 ~arm64
+=sys-devel/binutils-2.37_p1 ~amd64 ~arm64
+=sys-libs/binutils-libs-2.37_p1 ~amd64 ~arm64
 =sys-devel/gcc-8.3.0  ~amd64 ~arm64
 =sys-devel/gcc-9.3.0-r1 ~amd64 ~arm64
 =cross-aarch64-cros-linux-gnu/gcc-9.3.0-r1 ~arm64


### PR DESCRIPTION
# sys-{devel,libs}/binutils{,-libs}: Sync with Gentoo upstream; updates to 2.37

~The Gentoo upstream has not tested the package against [architectures](https://github.com/gentoo/gentoo/blob/6d0190c2229052c9bcc4c93d9729faf831f9e4e0/sys-devel/binutils/binutils-2.37.ebuild#L35-L36). It would not be a good idea to release before the upstream.~

To be merged with https://github.com/kinvolk/portage-stable/pull/191

## Testing done

~Jenkins Running, http://localhost:9091/job/os/job/manifest/3166/cldsv/~
Jenkins CI http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3534/cldsv/