### PR TITLE
app-admin/locksmith: bump commit ID

### DIFF
--- a/app-admin/locksmith/locksmith-9999.ebuild
+++ b/app-admin/locksmith/locksmith-9999.ebuild
@@ -11,7 +11,7 @@ inherit cros-workon systemd coreos-go
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="085ff774311dba979a53d049f6a776e156224437" # flatcar-master
+	CROS_WORKON_COMMIT="b54e4c68e0ac154402cb4d30511c70b02a6509f3" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
closes https://github.com/kinvolk/Flatcar/issues/407

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

This commit pulls the latest `flatcar-master` of `locksmith` - it includes the following PR:
- https://github.com/kinvolk/locksmith/pull/13
- https://github.com/kinvolk/locksmith/pull/11
- https://github.com/kinvolk/locksmith/pull/10
- https://github.com/kinvolk/locksmith/pull/9
- https://github.com/kinvolk/locksmith/pull/8
- https://github.com/kinvolk/locksmith/pull/6
- https://github.com/kinvolk/locksmith/pull/7
- https://github.com/kinvolk/locksmith/pull/5
## Testing done
* CI (:large_blue_circle: except for `kubeadm.*` on QEMU but not related) : http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3393/cldsv/