### PR TITLE
Fix path for amazon-ssm-agent in base-ec2.ign

### DIFF
--- a/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
+++ b/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
@@ -11,7 +11,7 @@
       {
         "name": "amazon-ssm-agent.service",
         "enabled": true,
-        "contents": "[Unit]\nDescription=amazon-ssm-agent\nAfter=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory=/usr/share/oem\nExecStart=/usr/share/oem/amazon-ssm-agent\nKillMode=process\nRestart=on-failure\nRestartForceExitStatus=SIGPIPE\nRestartSec=15min\n\n[Install]\nWantedBy=multi-user.target\n"
+        "contents": "[Unit]\nDescription=amazon-ssm-agent\nAfter=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory=/usr/share/oem\nExecStart=/usr/share/oem/bin/amazon-ssm-agent\nKillMode=process\nRestart=on-failure\nRestartForceExitStatus=SIGPIPE\nRestartSec=15min\n\n[Install]\nWantedBy=multi-user.target\n"
       }
     ]
   },


### PR DESCRIPTION
# Fix ExecStart path for amazon-ssm-agent in base-ec2.ign

The current ExecStart path for amazon-ssm-agent is incorrect. This PR fixes the path in the ignition config used to create the amazon-ssm-agent unit. 

## How to use

`systemctl status amazon-ssm-agent`

## Testing done

```
# ls -lahrt /usr/share/oem/amazon-ssm-agent
ls: cannot access '/usr/share/oem/amazon-ssm-agent': No such file or directory

# ls -lahrt /usr/share/oem/bin/amazon-ssm-agent
-rwxr-xr-x. 1 root root 31M Aug 18 01:28 /usr/share/oem/bin/amazon-ssm-agent
```

```● amazon-ssm-agent.service - amazon-ssm-agent
     Loaded: loaded (/etc/systemd/system/amazon-ssm-agent.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2021-08-25 14:40:52 UTC; 1 day 18h ago
   Main PID: 1256 (amazon-ssm-agen)
      Tasks: 9 (limit: 3419)
     Memory: 25.2M
        CPU: 514ms
     CGroup: /system.slice/amazon-ssm-agent.service
             └─1256 /usr/share/oem/bin/amazon-ssm-agent```
