### PR TITLE
profiles/.../sdk/package.use: add qemu SLIRP

### DIFF
--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -11,7 +11,7 @@ app-crypt/gnupg smartcard usb
 
 # for qemu
 app-arch/bzip2 static-libs
-app-emulation/qemu static-user -jpeg
+app-emulation/qemu static-user slirp -jpeg
 dev-libs/glib static-libs
 dev-libs/libaio static-libs
 dev-libs/libpcre static-libs


### PR DESCRIPTION
This change adds the "slirp" use flag to qemu (SDK only), enabling qemu's user networking. This fixes a bug where qemu is unable to start the Flatcar qemu image:
```
$ ./flatcar_production_qemu.sh
qemu-system-x86_64: Parameter 'type' expects a netdev backend type
```
The issue has been discussed on the qemu mailing list: https://www.mail-archive.com/qemu-devel@nongnu.org/msg786275.html

## How to use
- Build a flatcar image using the SDK, buld the qemu VM image from that
```
~/trunk/src/scripts $ ./build_image
[....]
~/trunk/src/scripts $ ./image_to_vm.sh --from ../build/images/amd64-usr/developer-<....>
[...]
~/trunk/src/scripts $ cd ../build/images/amd64-usr/developer-<....>
....$ /flatcar_production_qemu.sh
```

At this point, the current SDK's qemu fails with `qemu-system-x86_64: Parameter 'type' expects a netdev backend type`.

After applying the change in this PR, the qemu image launches successfully. 