### PR TITLE
Add alias for bcc tools to run in docker container

### DIFF
--- a/app-shells/bash/files/dot-bashrc
+++ b/app-shells/bash/files/dot-bashrc
@@ -16,12 +16,12 @@ fi
 
 
 # Put your fun stuff here.
-sysstat_debug_toolset=( sar iostat vmstat mpstat pidstat )
-bcc_debug_toolset = ( tcpretrans tcpconnect tcpaccept biolatency ext4slower ext4dist )
 
-for t in "${sysstat_debug_toolset[@]}"; do alias_tool "${t}"; done
-for t in "${bcc_debug_toolset[@]}"; do alias_tool "${t}"; done
-
-alias_tool() {
+alias_bcc_tool() {
     local tool="${1}"
+        alias iovisor-${tool}="docker run --rm -it -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/fs/bpf:/sys/fs/bpf --privileged --net host --pid host quay.io/iovisor/bcc /usr/share/bcc/tools/${tool}"
 }
+
+bcc_debug_toolset=( tcpretrans tcpconnect tcpaccept biolatency )
+
+for t in "${bcc_debug_toolset[@]}"; do alias_bcc_tool "${t}"; done

--- a/app-shells/bash/files/dot-bashrc
+++ b/app-shells/bash/files/dot-bashrc
@@ -16,3 +16,12 @@ fi
 
 
 # Put your fun stuff here.
+sysstat_debug_toolset=( sar iostat vmstat mpstat pidstat )
+bcc_debug_toolset = ( tcpretrans tcpconnect tcpaccept biolatency ext4slower ext4dist )
+
+for t in "${sysstat_debug_toolset[@]}"; do alias_tool "${t}"; done
+for t in "${bcc_debug_toolset[@]}"; do alias_tool "${t}"; done
+
+alias_tool() {
+    local tool="${1}"
+}


### PR DESCRIPTION
# Add alias for bcc tools to run in docker container
Added alias for bcc tool packages `tcpretrans tcpconnect tcpaccept biolatency ext4slower ext4dist` to run necessary debug tools

## Testing done
- `emerge-amd64-usr app-shells/bash`
- Run those alias in the image.
