### PR TITLE
profiles/base/use: add `minimal` useflag to `dev-lang/perl`

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -34,6 +34,9 @@ USE="${USE} -openmp"
 # The git-r3 eclass now depends on curl support, which is used in catalyst.
 BOOTSTRAP_USE="${BOOTSTRAP_USE} curl"
 
+# Add `minimal` useflag to prevent texinfo to pull dev-lang/perl with not required set of dependencies.
+BOOTSTRAP_USE="${BOOTSTRAP_USE} minimal"
+
 # Set SELinux policy
 POLICY_TYPES="targeted mcs mls"
 

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -141,3 +141,6 @@ sys-libs/ldb -lmdb -python
 
 # Enable nftables backend for the iptables instead of legacy backend
 net-firewall/iptables nftables
+
+# Install `perl` with a minimal set of dependencies
+dev-lang/perl minimal


### PR DESCRIPTION
Try to use `minimal` version of `Perl`.

## Testing done

jenkins (:large_blue_circle:): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3603/cldsv/

To be merged with: https://github.com/flatcar-linux/portage-stable/pull/215
