### PR TITLE
.github: get correct ebuild file name from old version

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -11,6 +11,26 @@ readonly BUILDBOT_USEREMAIL="buildbot@flatcar-linux.org"
 
 function enter() ( cd ../../..; exec cork enter -- $@ )
 
+# Return a valid ebuild file name for ebuilds of the given category name,
+# package name, and the old version. If the single ebuild file already exists,
+# then simply return that. If the file does not exist, then we should fall back
+# to a similar file including $VERSION_OLD.
+# For example, if VERSION_OLD == 1.0 and 1.0.ebuild does not exist, but only
+# 1.0-r1.ebuild is there, then we figure out its most similar valid name by
+# running "ls -1 ...*.ebuild | sort -ruV | head -n1".
+function get_ebuild_filename() {
+  local CATEGORY_NAME=$1
+  local PKGNAME_SIMPLE=$2
+  local VERSION_OLD=$3
+  local EBUILD_BASENAME="${CATEGORY_NAME}/${PKGNAME_SIMPLE}/${PKGNAME_SIMPLE}-${VERSION_OLD}"
+
+  if [ -f "${EBUILD_BASENAME}.ebuild" ]; then
+    echo "${EBUILD_BASENAME}.ebuild"
+  else
+    echo "$(ls -1 ${EBUILD_BASENAME}*.ebuild | sort -ruV | head -n1)"
+  fi
+}
+
 # caller needs to set pass a parameter as a branch name to be created.
 function checkout_branches() {
   TARGET_BRANCH=$1

--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -24,7 +24,7 @@ DOCKER_VERSION=$(sed -n "s/^DIST docker-\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p" app-e
 
 # we need to update not only the main ebuild file, but also its CONTAINERD_COMMIT,
 # which needs to point to COMMIT_HASH that matches with $VERSION_NEW from upstream containerd.
-containerdEbuildOldSymlink=$(ls -1 app-emulation/containerd/containerd-${VERSION_OLD}.ebuild)
+containerdEbuildOldSymlink=$(get_ebuild_filename "app-emulation" "containerd" "${VERSION_OLD}")
 containerdEbuildNewSymlink="app-emulation/containerd/containerd-${VERSION_NEW}.ebuild"
 containerdEbuildMain="app-emulation/containerd/containerd-9999.ebuild"
 git mv ${containerdEbuildOldSymlink} ${containerdEbuildNewSymlink}

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -22,7 +22,7 @@ fi
 
 # we need to update not only the main ebuild file, but also its DOCKER_GITCOMMIT,
 # which needs to point to COMMIT_HASH that matches with $VERSION_NEW from upstream docker-ce.
-dockerEbuildOld=$(ls -1 app-emulation/docker/docker-${VERSION_OLD}.ebuild)
+dockerEbuildOld=$(get_ebuild_filename "app-emulation" "docker" "${VERSION_OLD}")
 dockerEbuildNew="app-emulation/docker/docker-${VERSION_NEW}.ebuild"
 git mv ${dockerEbuildOld} ${dockerEbuildNew}
 sed -i "s/GIT_COMMIT=\(.*\)/GIT_COMMIT=${COMMIT_HASH}/g" ${dockerEbuildNew}

--- a/.github/workflows/firmware-apply-patch.sh
+++ b/.github/workflows/firmware-apply-patch.sh
@@ -21,7 +21,8 @@ if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   exit 0
 fi
 
-git mv $(ls -1 sys-kernel/coreos-firmware/coreos-firmware-${VERSION_OLD}.ebuild) "sys-kernel/coreos-firmware/coreos-firmware-${VERSION_NEW}.ebuild"
+EBUILD_FILENAME=$(get_ebuild_filename "sys-kernel" "coreos-firmware" "${VERSION_OLD}")
+git mv "${EBUILD_FILENAME}" "sys-kernel/coreos-firmware/coreos-firmware-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -25,7 +25,8 @@ if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   exit 0
 fi
 
-git mv $(ls -1 dev-lang/go/go-${VERSION_OLD}.ebuild) "dev-lang/go/go-${VERSION_NEW}.ebuild"
+EBUILD_FILENAME=$(get_ebuild_filename "dev-lang" "go" "${VERSION_OLD}")
+git mv "${EBUILD_FILENAME}" "dev-lang/go/go-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -23,7 +23,7 @@ if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   exit 0
 fi
 
-runcEbuildOld=$(ls -1 app-emulation/docker-runc/docker-runc-${VERSION_OLD}.ebuild)
+runcEbuildOld=$(get_ebuild_filename "app-emulation" "docker-runc" "${VERSION_OLD}")
 runcEbuildNew="app-emulation/docker-runc/docker-runc-${VERSION_NEW}.ebuild"
 git mv ${runcEbuildOld} ${runcEbuildNew}
 sed -i "s/${VERSION_OLD}/${VERSION_NEW}/g" ${runcEbuildNew}

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -23,9 +23,8 @@ fi
 # replace rust version in profiles/, e.g. package.accept_keywords.
 find profiles -name 'package.*' | xargs sed -i "s/=dev-lang\/rust-\S\+/=dev-lang\/rust-${VERSION_NEW}/"
 
-pushd "dev-lang/rust" >/dev/null || exit
-git mv $(ls -1 rust-${VERSION_OLD}.ebuild) "rust-${VERSION_NEW}.ebuild"
-popd >/dev/null || exit
+EBUILD_FILENAME=$(get_ebuild_filename "dev-lang" "rust" "${VERSION_OLD}")
+git mv "${EBUILD_FILENAME}" "dev-lang/rust/rust-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 


### PR DESCRIPTION
The bug fix https://github.com/flatcar-linux/coreos-overlay/pull/1129 caused a regression that Github Actions cannot determine a correct `$VERSION_OLD` if the old ebuild file has a suffix like `-r1`.
That's why recently Github Actions for firmware have failed to run.
We need to create a function to get a correct ebuild file name, by falling back to the most similar name, in case the expected ebuild file does not exist.
