### PR TITLE
.github: new Github workflow for open-vm-tools

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -87,4 +87,5 @@ function apply_patches() {
   git fetch origin
   git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
   git am "${SDK_OUTER_SRCDIR}"/third_party/coreos-overlay/0*.patch
+  rm -f "${SDK_OUTER_SRCDIR}"/third_party/coreos-overlay/0*.patch
 }

--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -31,6 +31,14 @@ function get_ebuild_filename() {
   fi
 }
 
+function prepare_git_repo() {
+  git config user.name "${BUILDBOT_USERNAME}"
+  git config user.email "${BUILDBOT_USEREMAIL}"
+  git reset --hard HEAD
+  git fetch origin
+  git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+}
+
 # caller needs to set pass a parameter as a branch name to be created.
 function checkout_branches() {
   TARGET_BRANCH=$1
@@ -81,11 +89,6 @@ function generate_patches() {
 }
 
 function apply_patches() {
-  git config user.name "${BUILDBOT_USERNAME}"
-  git config user.email "${BUILDBOT_USEREMAIL}"
-  git reset --hard HEAD
-  git fetch origin
-  git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
   git am "${SDK_OUTER_SRCDIR}"/third_party/coreos-overlay/0*.patch
   rm -f "${SDK_OUTER_SRCDIR}"/third_party/coreos-overlay/0*.patch
 }

--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -6,6 +6,8 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
+prepare_git_repo
+
 if ! checkout_branches "containerd-${VERSION_NEW}-${TARGET}"; then
   UPDATE_NEEDED=0
   exit 0

--- a/.github/workflows/containerd-releases-main.yml
+++ b/.github/workflows/containerd-releases-main.yml
@@ -2,6 +2,7 @@ name: Get the latest Containerd release for main
 on:
   schedule:
     - cron:  '00 8 * * 5'
+  workflow_dispatch:
 
 jobs:
   get-containerd-release:

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -6,6 +6,8 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
+prepare_git_repo
+
 if ! checkout_branches "docker-${VERSION_NEW}-${TARGET}"; then
   UPDATE_NEEDED=0
   exit 0

--- a/.github/workflows/docker-releases-main.yml
+++ b/.github/workflows/docker-releases-main.yml
@@ -2,6 +2,7 @@ name: Get the latest Docker release for main
 on:
   schedule:
     - cron:  '35 7 * * 3'
+  workflow_dispatch:
 
 jobs:
   get-docker-release:

--- a/.github/workflows/firmware-apply-patch.sh
+++ b/.github/workflows/firmware-apply-patch.sh
@@ -6,6 +6,8 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
+prepare_git_repo
+
 if ! checkout_branches "${VERSION_NEW}-${TARGET}"; then
   UPDATE_NEEDED=0
   exit 0

--- a/.github/workflows/firmware-releases-main.yml
+++ b/.github/workflows/firmware-releases-main.yml
@@ -2,6 +2,7 @@ name: Get the latest Linux Firmware release for main
 on:
   schedule:
     - cron:  '0 7 * * 4'
+  workflow_dispatch:
 
 jobs:
   get-firmware-release:

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -8,6 +8,8 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
+prepare_git_repo
+
 if ! checkout_branches "go-${VERSION_NEW}-${TARGET}"; then
   UPDATE_NEEDED=0
   exit 0

--- a/.github/workflows/go-releases-main.yml
+++ b/.github/workflows/go-releases-main.yml
@@ -2,6 +2,7 @@ name: Get the latest Go release for main
 on:
   schedule:
     - cron:  '15 7 * * 1'
+  workflow_dispatch:
 
 jobs:
   get-go-release:

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -8,6 +8,8 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
+prepare_git_repo
+
 if ! checkout_branches "linux-${VERSION_NEW}-${TARGET}"; then
   UPDATE_NEEDED=0
   exit 0

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -2,6 +2,7 @@ name: Get the latest Kernel release for the Alpha maintenance branch
 on:
   schedule:
     - cron:  '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   get-kernel-release:

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -2,6 +2,7 @@ name: Get the latest Kernel release for the Beta maintenance branch
 on:
   schedule:
     - cron:  '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   get-kernel-release:

--- a/.github/workflows/kernel-releases-lts-2021.yml
+++ b/.github/workflows/kernel-releases-lts-2021.yml
@@ -2,6 +2,7 @@ name: Get the latest Kernel release for the LTS-2021 maintenance branch
 on:
   schedule:
     - cron:  '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   get-kernel-release:

--- a/.github/workflows/kernel-releases-main.yml
+++ b/.github/workflows/kernel-releases-main.yml
@@ -2,6 +2,7 @@ name: Get the latest Kernel release for main
 on:
   schedule:
     - cron:  '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   get-kernel-release:

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -2,6 +2,7 @@ name: Get the latest Kernel release for the Stable maintenance branch
 on:
   schedule:
     - cron:  '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   get-kernel-release:

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -6,6 +6,8 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
+prepare_git_repo
+
 if ! checkout_branches "runc-${VERSION_NEW}-${TARGET}"; then
   UPDATE_NEEDED=0
   exit 0

--- a/.github/workflows/runc-releases-main.yml
+++ b/.github/workflows/runc-releases-main.yml
@@ -2,6 +2,7 @@ name: Get the latest Runc release for main
 on:
   schedule:
     - cron:  '50 7 * * 4'
+  workflow_dispatch:
 
 jobs:
   get-runc-release:

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -6,6 +6,8 @@ UPDATE_NEEDED=1
 
 . .github/workflows/common.sh
 
+prepare_git_repo
+
 if ! checkout_branches "rust-${VERSION_NEW}-${TARGET}"; then
   UPDATE_NEEDED=0
   exit 0

--- a/.github/workflows/rust-release-main.yml
+++ b/.github/workflows/rust-release-main.yml
@@ -2,6 +2,7 @@ name: Get the latest Rust release for main
 on:
   schedule:
     - cron:  '20 7 * * 2'
+  workflow_dispatch:
 
 jobs:
   get-rust-release:

--- a/.github/workflows/vmware-apply-patch.sh
+++ b/.github/workflows/vmware-apply-patch.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+UPDATE_NEEDED=1
+
+. .github/workflows/common.sh
+
+prepare_git_repo
+
+if ! checkout_branches "${VERSION_NEW}-${TARGET}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
+
+# Update app-emulation/open-vm-tools
+
+pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
+
+# Parse the Manifest file for already present source files and keep the latest version in the current series
+VERSION_OLD=$(sed -n "s/^DIST open-vm-tools-\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/p" app-emulation/open-vm-tools/Manifest | sort -ruV | head -n1)
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest open-vm-tools, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
+
+EBUILD_FILENAME_OVT=$(get_ebuild_filename "app-emulation" "open-vm-tools" "${VERSION_OLD}")
+git mv "${EBUILD_FILENAME_OVT}" "app-emulation/open-vm-tools/open-vm-tools-${VERSION_NEW}.ebuild"
+
+# We need to also replace the old build number with the new build number in the ebuild.
+sed -i -e "s/^\(MY_P=.*-\)[0-9]*\"$/\1${BUILD_NUMBER}\"/" app-emulation/open-vm-tools/open-vm-tools-${VERSION_NEW}.ebuild
+
+popd >/dev/null || exit
+
+generate_patches app-emulation open-vm-tools open-vm-tools
+
+apply_patches
+
+
+# Update coreos-base/oem-vmware
+
+pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
+
+EBUILD_FILENAME_OEM=$(get_ebuild_filename "coreos-base" "oem-vmware" "${VERSION_OLD}")
+git mv "${EBUILD_FILENAME_OEM}" "coreos-base/oem-vmware/oem-vmware-${VERSION_NEW}.ebuild"
+
+popd >/dev/null || exit
+
+generate_patches coreos-base oem-vmware oem-vmware
+
+apply_patches
+
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
+echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"

--- a/.github/workflows/vmware-releases-main.yml
+++ b/.github/workflows/vmware-releases-main.yml
@@ -2,6 +2,7 @@ name: Get the latest open-vm-tools release for main
 on:
   schedule:
     - cron:  '0 7 * * 3'
+  workflow_dispatch:
 
 jobs:
   get-vmware-release:

--- a/.github/workflows/vmware-releases-main.yml
+++ b/.github/workflows/vmware-releases-main.yml
@@ -1,0 +1,47 @@
+name: Get the latest open-vm-tools release for main
+on:
+  schedule:
+    - cron:  '0 7 * * 3'
+
+jobs:
+  get-vmware-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest open-vm-tools release
+        id: fetch-latest-release
+        run: |
+          git clone https://github.com/vmware/open-vm-tools
+          versionMain=$(git -C open-vm-tools ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/stable-[0-9]*\.[0-9]*\.[0-9]*$/s/^refs\/tags\/stable-//p" | sort -ruV | head -n1)
+          buildNumber=$(curl -sSL https://api.github.com/repos/vmware/open-vm-tools/releases/latest | jq -r '.assets[0].name' | sed -n "s/^open-vm-tools-${versionMain}*-\([0-9]*\)\..*/\1/p")
+          rm -rf open-vm-tools
+          echo ::set-output name=BASE_BRANCH_MAIN::main
+          echo ::set-output name=BUILD_NUMBER::$(echo ${buildNumber})
+          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for main
+        id: apply-patch-main
+        env:
+          TARGET: main
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          BUILD_NUMBER: ${{ steps.fetch-latest-release.outputs.BUILD_NUMBER }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+        run: .github/workflows/vmware-apply-patch.sh
+      - name: Create pull request for main
+        uses: peter-evans/create-pull-request@v3
+        if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          branch: vmware-${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}-${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade open-vm-tools in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          commit-message: Upgrade open-vm-tools in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          body: Upgrade open-vm-tools in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          labels: main


### PR DESCRIPTION
Automatically update `coreos/open-vm-tools` as well as `coreos-base/oem-vmware`.
Get the latest open-vm-tools release number, and get its build number from the Github repo, and replace the old build number with the new one.
Also sync `coreos-base/oem-vmware` in line with `open-vm-tools`.

To do that, we need to also split git repo init part into `prepare_git_repo`, to prevent some corner cases, where applying multiple patches does not work because the latter overwrites the former patch.
We need to also clean up an unnecessary patch file.
