### PR TITLE
profiles: Drop keywords for sys-fs/mtools

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -26,9 +26,6 @@ dev-util/checkbashisms
 # Must use the same version across all architectures
 =dev-libs/protobuf-2.6.1-r3
 
-# mtools 4.0.18 has '-i' flag for working with images
-=sys-fs/mtools-4.0.18
-
 # All versions are ~amd64 and not enabled on arm64
 =sys-apps/nvme-cli-1.1 **
 


### PR DESCRIPTION
We just updated this package to 4.0.35, which is declared stable for
both amd64 and arm64.

To be merged together with https://github.com/flatcar-linux/portage-stable/pull/226.

CI: http://localhost:9091/job/os/job/manifest/3869/cldsv/
