### PR TITLE
app-crypt/trousers: Skip tscd.service for TPM2 devices

### DIFF
--- a/app-crypt/trousers/files/tcsd.service
+++ b/app-crypt/trousers/files/tcsd.service
@@ -4,6 +4,7 @@ ConditionPathExists=/dev/tpm0
 
 [Service]
 User=tss
+ExecCondition=/bin/bash -c "/usr/bin/test $(cat /sys/class/tpm/*/tpm_version_major | grep -m 1 1 || echo 0) -eq 1"
 ExecStart=/usr/sbin/tcsd -f
 
 [Install]


### PR DESCRIPTION
trousers supports TPM 1.2, and fails for TPM 2. This commits
skips the tcsd service if TPM 2 is detected.

Fixes https://github.com/flatcar-linux/Flatcar/issues/208

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>

## Testing done

CI Running http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3911/cldsv/