### PR TITLE
app-crypt/trousers: Skip tscd.service for TPM2 devices (using ConditionSecurity)

### DIFF
--- a/app-crypt/trousers/files/tcsd.service
+++ b/app-crypt/trousers/files/tcsd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=TCG Core Services Daemon
 ConditionPathExists=/dev/tpm0
+ConditionSecurity=!tpm2
 
 [Service]
 User=tss


### PR DESCRIPTION
trousers supports TPM 1.2, and fails for TPM 2. This commits
skips the tcsd service if TPM 2 is detected.

Uses ConditionSecurity introduced in systemd v248

Fixes flatcar-linux/Flatcar#208

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>

To be merged as a follow up PR to https://github.com/flatcar-linux/coreos-overlay/pull/1364

## Testing done

CI Running: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3914/cldsv/
