### PR TITLE
Remove nmap keyword from arm64/package.accept_keywords

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -46,7 +46,6 @@ dev-util/checkbashisms *
 =dev-util/ninja-1.8.2 ~arm64
 =dev-util/re2c-0.16 ~arm64
 dev-util/patchelf *
-=net-analyzer/nmap-7.40 ~arm64
 =net-analyzer/tcpdump-4.9.2 ~arm64
 =net-dialup/minicom-2.7.1 ~arm64
 =net-dns/bind-tools-9.11.2_p1 ~arm64


### PR DESCRIPTION
# Remove nmap keyword from arm64/package.accept_keywords

Now nmap 7.92 is stable also for arm64.

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3946/cldsv