### PR TITLE
Update accept keyword for cryptsetup 2.4.1

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -91,7 +91,6 @@ sys-apps/dtc ~arm64
 ~sys-firmware/sgabios-0.1_pre8 ~arm64
 =sys-fs/btrfs-progs-4.10.2 ~arm64
 =sys-fs/btrfs-progs-4.19.1 ~arm64
-=sys-fs/cryptsetup-1.7.5 ~arm64
 =sys-fs/lsscsi-0.28 ~arm64
 =sys-fs/quota-4.04-r1 ~arm64
 =sys-libs/binutils-libs-2.29.1-r1 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -79,7 +79,7 @@ dev-util/checkbashisms
 =virtual/rust-1.55.0 ~amd64 ~arm64
 =dev-lang/rust-1.55.0 ~amd64 ~arm64
 
-=sys-fs/cryptsetup-2.0.3 ~amd64
+=sys-fs/cryptsetup-2.4.1-r1 ~amd64 ~arm64
 
 =sys-libs/libseccomp-2.5.0 ~amd64 ~arm64
 


### PR DESCRIPTION
# Update accept keyword for cryptsetup 2.4.1

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3945/cldsv