### PR TITLE
.github: update accept_keywords also for virtual/rust

### DIFF
--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -22,8 +22,10 @@ if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
   exit 0
 fi
 
-# replace rust version in profiles/, e.g. package.accept_keywords.
-find profiles -name 'package.*' | xargs sed -i "s/=dev-lang\/rust-\S\+/=dev-lang\/rust-${VERSION_NEW}/"
+# Replace (dev-lang/virtual)/rust versions in profiles/, e.g. package.accept_keywords.
+# Try to match all kinds of version specifiers, e.g. >=, <=, =, ~.
+find profiles -name 'package.*' | xargs sed -i "s/\([><]*=\|~\)*dev-lang\/rust-\S\+/\1dev-lang\/rust-${VERSION_NEW}/"
+find profiles -name 'package.*' | xargs sed -i "s/\([><]*=\|~\)*virtual\/rust-\S\+/\1virtual\/rust-${VERSION_NEW}/"
 
 EBUILD_FILENAME=$(get_ebuild_filename "dev-lang" "rust" "${VERSION_OLD}")
 git mv "${EBUILD_FILENAME}" "dev-lang/rust/rust-${VERSION_NEW}.ebuild"


### PR DESCRIPTION
PR https://github.com/flatcar-linux/coreos-overlay/pull/432 started to replace `dev-lang/rust` in accept_keywords with its new version.

However, its corresponding `virtual/rust` has never been updated.
That issue had been hidden until https://github.com/flatcar-linux/coreos-overlay/pull/1276/commits/4463efcfd4f5d21b6e16348dedee071084e0c019 started adding `virtual/rust` to accept_keywords.
Unlike `dev-lang/rust`, keywords for `virtual/rust` stayed with old versions.
As a result, subsequent Github Actions PRs for rust become all invalid, so build failures.

Fix the issue by replacing versions of `virtual/rust` with new versions.
Also try to match with version specifiers, not only `=` but also `>=`, `<=`, `~`.
