### PR TITLE
sec-policy/selinux-base: force sequential build in src_configure

### DIFF
--- a/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
+++ b/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
@@ -81,7 +81,11 @@ src_configure() {
 
 	# Prepare initial configuration
 	cd "${S}/refpolicy" || die
-	emake conf
+	# Parallel make fails with:
+	#   python3 -t -t -E -W error support/sedoctool.py -b policy/booleans.conf -m policy/modules.conf -x doc/policy.xml
+	#   support/sedoctool.py exiting for: Error while parsing xml
+	#   make: *** [Makefile:415: conf.intermediate] Error 1
+	emake -j1 conf
 
 	# Setup the policies based on the types delivered by the end user.
 	# These types can be "targeted", "strict", "mcs" and "mls".


### PR DESCRIPTION
# sec-policy/selinux-base: force `emake -j1` in src_configure

The build has been failing occasionally in src_configure(), due to some kind of race condition. Check to see if forcing `-j1` helps.

## How to use

Mostly shows up during bootstrap, so run `boostrap_sdk`.

## Testing done

CI ran here: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3963/cldsv/. Qemu test flaked so I restarted and it passed.
