### PR TITLE
profiles: accept keywords for wget 1.21.2.

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -115,3 +115,7 @@ dev-util/checkbashisms
 
 # dev-libs/openssl-3.0.0 is still in testing phase at this point
 =dev-libs/openssl-3.0.0 ~amd64 ~arm64
+
+# To address security issues like CVE-2021-31879, we need to accept
+# keywords for wget 1.21.2.
+=net-misc/wget-1.21.2 ~amd64 ~arm64


### PR DESCRIPTION
To be able to update `net-misc/wget` to 1.21.2, accept keywords for both `~amd64` and `~arm64`.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/233 .

## How to use

```
emerge-amd64-usr net-misc/wget
```

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4010/cldsv
