### PR TITLE
selinux-base: fix build issue during boostrap

### DIFF
--- a/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
+++ b/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
@@ -31,7 +31,7 @@ RDEPEND=">=sys-apps/policycoreutils-2.8
 	>=sys-apps/checkpolicy-2.8
 "
 DEPEND="${RDEPEND}"
-# flatcar: BDEPEND on python3[xm] - normally pulled in through policycoreutils
+# flatcar: BDEPEND on python3[xml] - normally pulled in through policycoreutils
 # but we made that dep conditional on USE=python
 BDEPEND="sys-devel/m4
     >=dev-lang/python-3[xml]

--- a/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
+++ b/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
@@ -81,11 +81,7 @@ src_configure() {
 
 	# Prepare initial configuration
 	cd "${S}/refpolicy" || die
-	# Parallel make fails with:
-	#   python3 -t -t -E -W error support/sedoctool.py -b policy/booleans.conf -m policy/modules.conf -x doc/policy.xml
-	#   support/sedoctool.py exiting for: Error while parsing xml
-	#   make: *** [Makefile:415: conf.intermediate] Error 1
-	emake -j1 conf
+	emake conf
 
 	# Setup the policies based on the types delivered by the end user.
 	# These types can be "targeted", "strict", "mcs" and "mls".

--- a/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
+++ b/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
@@ -31,7 +31,11 @@ RDEPEND=">=sys-apps/policycoreutils-2.8
 	>=sys-apps/checkpolicy-2.8
 "
 DEPEND="${RDEPEND}"
-BDEPEND="sys-devel/m4"
+# flatcar: BDEPEND on python3[xm] - normally pulled in through policycoreutils
+# but we made that dep conditional on USE=python
+BDEPEND="sys-devel/m4
+    >=dev-lang/python-3[xml]
+"
 
 
 # flatcar changes


### PR DESCRIPTION
# selinux-base: fix build issue during boostrap

selinux-base needs python with xml support, but the dependency was implicit through policycoreutils, and we removed that dependency downstream. This shows up during stage3 of bootstrap_sdk. Fix the issue by adding an explicit dependency and removing the previous attempt at fixing the issue (forcing sequential build, which does nothing).

## How to use

`./boostrap_sdk`.

## Testing done

Will let CI run.
