### PR TITLE
profiles: delete unnecessary accept_keywords

### DIFF
--- a/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
+++ b/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
@@ -60,8 +60,4 @@ DEPEND="${DEPEND}
 	)
 	sys-devel/m4"
 
-# Required by dev-lang/spidermonkey-1.8.5
-DEPEND="${DEPEND}
-	sys-devel/autoconf:2.1"
-
 RDEPEND="${DEPEND}"

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -1,106 +1,135 @@
 # arm64 keywords
 # Keep these in alphabetical order.
 
-=app-arch/bzip2-1.0.6-r8 ~arm64
+# needed by arm64-native SDK
+app-misc/editor-wrapper *
+
+=app-misc/jq-1.6-r3 ~arm64
 ~app-arch/pbzip2-1.1.12 ~arm64
 =app-arch/pigz-2.3.3 ~arm64
-=app-crypt/mit-krb5-1.14.2 ~arm64
-=app-emulation/open-vmdk-1.0 *
-=app-eselect/eselect-rust-20190311 ~arm64
-app-misc/editor-wrapper *
 =app-text/asciidoc-8.6.9-r3 ~arm64
+=cross-aarch64-cros-linux-gnu/gcc-9.3.0-r1 ~arm64
 =dev-cpp/gflags-2.2.0 ~arm64
 =dev-cpp/glog-0.3.4-r1 ~arm64
 =dev-embedded/u-boot-tools-2019.10 ~arm64
+
+# needed by arm64-native SDK
 =dev-lang/nasm-2.14.02 *
-=dev-lang/perl-5.24.1-r2 ~arm64
+
 =dev-lang/swig-3.0.12 ~arm64
 =dev-lang/yasm-1.3.0-r1 ~arm64
-=dev-libs/ding-libs-0.4.0 **
-=dev-libs/elfutils-0.169-r1 ~arm64
 =dev-libs/libassuan-2.5.1 ~arm64
 =dev-libs/libevent-2.1.8 ~arm64
 =dev-libs/liblinear-210-r1 ~arm64
 =dev-libs/libnl-3.2.27 ~arm64
-=dev-libs/libpcre2-10.30 ~arm64
-=dev-libs/libpcre-8.41 ~arm64
 =dev-libs/libusb-1.0.21 ~arm64
+
+# needed to force enable userspace-rcu for arm64
 =dev-libs/userspace-rcu-0.9.1 **
-=dev-perl/libintl-perl-1.240.0-r2 ~arm64
+
 =dev-perl/Text-Unidecode-1.270.0 ~arm64
+
+# needed by arm64-native SDK
 =dev-python/astroid-1.4.8 *
 =dev-python/backports-functools-lru-cache-1.3 *
 =dev-python/configparser-3.5.0 *
 =dev-python/ctypesgen-0_p72-r1 *
+
 =dev-python/flake8-2.5.4 ~arm64
+
+# needed by arm64-native SDK
 =dev-python/isort-4.2.5 *
 =dev-python/lazy-object-proxy-1.2.1 *
+
 =dev-python/mako-1.0.3 ~arm64
+
+# needed by arm64-native SDK
 =dev-python/mccabe-0.2.1 *
+
 dev-python/pep8 ~arm64
+
+# needed by arm64-native SDK
 =dev-python/pyflakes-0.8.1 *
 =dev-python/pylint-1.6.5-r1 *
 =dev-python/wrapt-1.10.5 *
 dev-util/checkbashisms *
-=dev-util/meson-0.43.0 ~arm64
+
 =dev-util/ninja-1.8.2 ~arm64
-=dev-util/re2c-0.16 ~arm64
+
+# needed by arm64-native SDK
 dev-util/patchelf *
-=net-analyzer/tcpdump-4.9.2 ~arm64
+
 =net-dialup/minicom-2.7.1 ~arm64
-=net-dns/bind-tools-9.11.2_p1 ~arm64
 =net-dns/c-ares-1.17.2 ~arm64
-=net-dns/dnsmasq-2.78 ~arm64
 =net-firewall/conntrack-tools-1.4.5 ~arm64
-=net-firewall/ebtables-2.0.10.4-r1 ~arm64
 =net-firewall/ipset-6.29 ~arm64
 =net-libs/http-parser-2.6.2 ~arm64
-=net-libs/libmicrohttpd-0.9.52 **
 =net-libs/libnetfilter_conntrack-1.0.8 ~arm64
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_cttimeout-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_queue-1.0.3 ~arm64
-=net-libs/libnfnetlink-1.0.1 ~arm64
-=net-libs/libnftnl-1.0.6 **
 =net-misc/bridge-utils-1.5 ~arm64
+=net-misc/curl-7.79.1 ~arm64
+
+# needed to force enable iperf for arm64
 =net-misc/iperf-3.1.3 **
+
 =net-misc/socat-1.7.3.2 ~arm64
-=net-nds/openldap-2.4.44 ~arm64
 =perl-core/File-Path-2.130.0 ~arm64
-sys-apps/checkpolicy *
-sys-apps/debianutils *
+=sec-policy/selinux-base-2.20200818-r2 ~arm64
+=sec-policy/selinux-base-policy-2.20200818-r2 ~arm64
+=sec-policy/selinux-unconfined-2.20200818-r2 ~arm64
+=sec-policy/selinux-virt-2.20200818-r2 ~arm64
 sys-apps/dtc ~arm64
+=sys-apps/checkpolicy-3.1 ~arm64
+
+# needed by arm64-native SDK
+sys-apps/debianutils *
+
 =sys-apps/i2c-tools-3.1.1-r1 ~arm64
+
+# needed to force enable lshw for arm64
 =sys-apps/lshw-02.17b-r2 **
+
 =sys-apps/man-db-2.7.6.1-r2 ~arm64
 =sys-apps/policycoreutils-3.1-r2 ~arm64
+=sys-apps/kexec-tools-2.0.17-r1 ~arm64
+
+# needed by arm64-native SDK
 =sys-apps/pv-1.3.4 *
+
+# needed to force enable rng-tools for arm64
 =sys-apps/rng-tools-5-r2 **
+
 =sys-apps/sandbox-2.12 ~arm64
 =sys-apps/semodule-utils-3.1 ~arm64
+
+# needed to force enable smartmontools for arm64
 =sys-apps/smartmontools-6.4 **
+
 =sys-block/parted-3.2-r1 ~arm64
 =sys-block/thin-provisioning-tools-0.7.0 ~arm64
 =sys-boot/efibootmgr-15 ~arm64
 =sys-boot/gnu-efi-3.0.3 ~arm64
+
+# needed to force enable ipvsadm for arm64
 =sys-cluster/ipvsadm-1.27-r1 **
+
 =sys-firmware/edk2-aarch64-18.02 **
+=sys-firmware/edk2-ovmf-201905 ~arm64
 =sys-firmware/ipxe-1.0.0_p20190728 ~arm64
 =sys-firmware/seabios-1.12.0 ~arm64
 ~sys-firmware/sgabios-0.1_pre8 ~arm64
-=sys-fs/btrfs-progs-4.10.2 ~arm64
 =sys-fs/btrfs-progs-4.19.1 ~arm64
 =sys-fs/lsscsi-0.28 ~arm64
 =sys-fs/quota-4.04-r1 ~arm64
-=sys-libs/binutils-libs-2.29.1-r1 ~arm64
 =sys-libs/efivar-31 ~arm64
 =sys-libs/libcap-ng-0.7.8 ~arm64
 =sys-libs/libselinux-3.1-r1 ~arm64
 =sys-libs/libsemanage-3.1-r1 ~arm64
 =sys-libs/libsepol-3.1 ~arm64
 =sys-power/iasl-20161222 ~arm64
+=sys-process/tini-0.18.0 ~arm64
 =virtual/krb5-0-r1 ~arm64
 =virtual/libusb-1-r2 ~arm64
-=virtual/perl-File-Path-2.130.0 ~arm64
-=virtual/cdrtools-0 *
 =x11-libs/pixman-0.32.8 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -2,120 +2,75 @@
 # Copyright (c) 2013 The CoreOS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 
-=dev-util/perf-4.9.13 ~amd64
-
-# Everything needed for the boot engine
->=sys-apps/kexec-tools-2.0.4-r1 ~amd64
-=sys-kernel/dracut-049 **
-
-# Needed by coreos-oem-gce
-dev-python/boto
-
-# efitools and dependency libraries for signing kernel images
->=sys-boot/gnu-efi-3.0u		~amd64
->=app-crypt/efitools-1.4.1-r2	~amd64
-
-# no version marked stable upstream
-dev-util/checkbashisms
-
-# jq 1.5-r2 for heap overflow fix
-# https://bugs.gentoo.org/show_bug.cgi?id=580606
-# jq 1.6-r3 for CVE-2015-8863
->=app-misc/jq-1.5-r2 ~amd64 ~arm64
-
-# Must use the same version across all architectures
-=dev-libs/protobuf-2.6.1-r3
-
-# All versions are ~amd64 and not enabled on arm64
-=sys-apps/nvme-cli-1.1 **
-
-# CVE-2017-8779
-=net-nds/rpcbind-0.2.4-r1
-
-# Pick up fixes for bugs introduced in 4.0
-=sys-fs/dosfstools-4.1 **
-
-# iproute2 4.13 includes a patch to avoid leaking netns mounts in rkt
-# https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git/commit/?id=d6a4076b6ba6547d7e52c377a7c58c56eb5ea16e
-=sys-apps/iproute2-4.13.0 ~amd64 ~arm64
-
-# Upgrade to GCC 9.3.0 to support latest glibc builds
-=sys-devel/gcc-config-1.9.1 ~amd64 ~arm64
-=sys-devel/binutils-2.37_p1 ~amd64 ~arm64
-=sys-libs/binutils-libs-2.37_p1 ~amd64 ~arm64
-=sys-devel/gcc-8.3.0  ~amd64 ~arm64
-=sys-devel/gcc-9.3.0-r1 ~amd64 ~arm64
-=cross-aarch64-cros-linux-gnu/gcc-9.3.0-r1 ~arm64
-=cross-x86_64-cros-linux-gnu/gcc-9.3.0-r1 ~amd64
-
-# Force upgrades to work around catalyst problems while upgrading ncurses.
-=sys-apps/gptfdisk-1.0.3 ~amd64 ~arm64
-
-# Choose the newer spidermonkey revision to support GCC 8.3.0.
-# https://bugs.gentoo.org/686744
-=dev-lang/spidermonkey-1.8.5-r7
-
-=sys-firmware/edk2-ovmf-201905 ~arm64
-
-=sys-auth/google-oslogin-20180611 **
-
-=sys-process/tini-0.18.0 ~arm64
-
-=sys-libs/libsepol-2.4 **
-=sys-libs/libselinux-2.4 **
-=sys-apps/checkpolicy-3.1 **
-=sec-policy/selinux-base-2.20200818-r2 **
-=sec-policy/selinux-base-policy-2.20200818-r2 **
-=sec-policy/selinux-unconfined-2.20200818-r2 **
-=sec-policy/selinux-virt-2.20200818-r2 **
-
-=net-misc/openssh-8.7_p1-r1 ~amd64 ~arm64
-
-=sys-firmware/sgabios-0.1_pre8-r1 ~amd64 ~arm64
-
-=coreos-devel/fero-client-0.1.1 **
-
-# Accept unstable host Rust compilers
-=virtual/rust-1.56.1 ~amd64 ~arm64
-=dev-lang/rust-1.56.1 ~amd64 ~arm64
-
-=sys-fs/cryptsetup-2.4.1-r1 ~amd64 ~arm64
-
-=sys-libs/libseccomp-2.5.0 ~amd64 ~arm64
-
->=dev-util/dwarves-1.18 ~amd64
->=dev-libs/elfutils-0.178 ~amd64
-
-=sys-fs/multipath-tools-0.8.5 ~amd64 ~arm64
-
 =app-arch/zstd-1.4.9 ~amd64 ~arm64
-
-=net-libs/gnutls-3.7.1 ~amd64 ~arm64
-
-=net-nds/openldap-2.4.58 ~amd64 ~arm64
-
-=dev-libs/libxml2-2.9.12-r2 ~amd64 ~arm64
-
-=dev-libs/libgcrypt-1.9.4 ~amd64 ~arm64
-
-=net-libs/libnftnl-1.2.0 ~amd64 ~arm64
-
-=net-misc/curl-7.79.1 ~arm64
-
-# We need 2.3.2, but it still marked as unstable on arm64. Can't
-# update the package to a newer revision from gentoo (where it is
-# already stabilised for both amd64 and arm64) until we move off from
-# python3.6.
-=sys-libs/talloc-2.3.2 ~amd64 ~arm64
 
 # To address security issues like CVE-2021-3770, we need to acccept
 # keywords for vim 8.2.3428.
 =app-editors/vim-8.2.3428 ~amd64 ~arm64
 =app-editors/vim-core-8.2.3428 ~amd64 ~arm64
 
+=coreos-devel/fero-client-0.1.1 **
+
+# Accept unstable host Rust compilers
+=dev-lang/rust-1.56.1 ~amd64 ~arm64
+=virtual/rust-1.56.1 ~amd64 ~arm64
+
 # dev-libs/openssl-3.0.0 is still in testing phase at this point
 =dev-libs/openssl-3.0.0 ~amd64 ~arm64
+
+# Needed by coreos-oem-gce
+dev-python/boto ~amd64 ~arm64
+
+# no version marked stable upstream
+dev-util/checkbashisms
+
+=dev-libs/elfutils-0.178 ~amd64
+
+=dev-libs/libgcrypt-1.9.4 ~amd64 ~arm64
+
+=dev-libs/libxml2-2.9.12-r2 ~amd64 ~arm64
+
+=dev-util/dwarves-1.19 ~amd64
+
+=net-libs/gnutls-3.7.1 ~amd64 ~arm64
+
+=net-libs/libmicrohttpd-0.9.55 ~amd64 ~arm64
+
+=net-misc/openssh-8.7_p1-r1 ~amd64 ~arm64
 
 # To address security issues like CVE-2021-31879, we need to accept
 # keywords for wget 1.21.2.
 =net-misc/wget-1.21.2 ~amd64 ~arm64
+
+=net-nds/openldap-2.4.58 ~amd64 ~arm64
+
+# CVE-2017-8779
+=net-nds/rpcbind-0.2.4-r1 ~amd64 ~arm64
+
+# All versions are ~amd64 and not enabled on arm64
+=sys-apps/nvme-cli-1.1 **
+
+# Upgrade to GCC 9.3.0 to support latest glibc builds
+=sys-devel/binutils-2.37_p1 ~amd64 ~arm64
+=sys-devel/gcc-config-1.9.1 ~amd64 ~arm64
+=sys-devel/gcc-8.3.0  ~amd64 ~arm64
+=sys-devel/gcc-9.3.0-r1 ~amd64 ~arm64
+=sys-libs/binutils-libs-2.37_p1 ~amd64 ~arm64
+=cross-x86_64-cros-linux-gnu/gcc-9.3.0-r1 ~amd64
+
+=sys-firmware/sgabios-0.1_pre8-r1 ~amd64 ~arm64
+
+=sys-fs/cryptsetup-2.4.1-r1 ~amd64 ~arm64
+
+# Pick up fixes for bugs introduced in 4.0
+=sys-fs/dosfstools-4.1 ~amd64 ~arm64
+
+=sys-fs/multipath-tools-0.8.5 ~amd64 ~arm64
+
+=sys-libs/libseccomp-2.5.0 ~amd64 ~arm64
+
+# We need 2.3.2, but it still marked as unstable on arm64. Can't
+# update the package to a newer revision from gentoo (where it is
+# already stabilised for both amd64 and arm64) until we move off from
+# python3.6.
+=sys-libs/talloc-2.3.2 ~amd64 ~arm64

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -48,8 +48,6 @@ net-libs/libmicrohttpd -ssl
 # disable kernel config detection and module building
 net-firewall/ipset -modules
 
-dev-lang/spidermonkey minimal
-
 # do not pull in x11-misc/shared-mime-info
 dev-libs/glib -mime
 

--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -1,3 +1,1 @@
-
-# Accept perl libs required to build >=samba-4.12
-dev-perl/Parse-Yapp ~amd64 ~arm64
+=app-crypt/efitools-1.8.1 ~amd64 ~arm64

--- a/profiles/features/systemd/package.accept_keywords
+++ b/profiles/features/systemd/package.accept_keywords
@@ -1,7 +1,3 @@
 # Various dependencies that also need to be up-to-date
 sys-apps/hwids                  ~amd64 ~x86
 sys-apps/kmod                   ~amd64 ~x86
-virtual/udev                    ~amd64 ~x86
-
-# use the latest libmicrohttpd that builds.
-=net-libs/libmicrohttpd-0.9.34


### PR DESCRIPTION
Delete unnecessary ebuilds from accept_keywords.

## profiles: base accept_keywords

Clean up unnecessary ebuilds from base accept_keywords like below.
Sort alphabetically.

* `app-crypt/efitools`: move to sdk
* `app-misc/jq`: move to arm64
* `cross-aarch64-cros-linux-gnu/gcc`: move 9.3.0-r1 to arm64
* `dev-lang/spidermonkey` is not needed any more.
* `dev-libs/protobuf` 3.5.2 is already stable.
* `dev-libs/elfutils`: specify explicit version 0.178
* `dev-python/boto`: specify explicit keywords ~amd64, ~arm64.
* `dev-util/dwarves`: specify explicit version 1.19
* `dev-util/perf` 5.8 is already stable.
* `net-misc/curl`: move 7.79.1 to arm64
* `net-nds/rpcbind`: specify explicit keywords ~amd64, ~arm64.
* `net-libs/libnftnl` 1.2.0-r1 is already stable.
* `net-libs/libmicrohttpd`: move from arm64, specify explicit keywords.
* `sec-policy/selinux-base`: move to arm64.
* `sec-policy/selinux-base-policy`: move to arm64.
* `sec-policy/selinux-unconfined`: move to arm64.
* `sec-policy/selinux-virt`: move to arm64.
* `sys-apps/checkpolicy`: move to arm64.
* `sys-apps/gptfdisk` 1.0.7 is already stable.
* `sys-apps/iproute2` 5.8.0 is already stable.
* `sys-apps/kexec-tools` 2.0.17-r1 is already stable.
* `sys-auth/google-oslogin` 20200910.00 is already stable.
* `sys-kernel/dracut` 053-r1 is already stable.
* `sys-boot/gnu-efi` 3.0.3 is already stable.
* `sys-firmware/edk2-ovmf`: move to arm64
* `sys-fs/dosfstools`: specify explicit keywords ~amd64, ~arm64.
* `sys-process/tini`: move to arm64
* `sys-libs/libselinux`: already configured in arm64
* `sys-libs/libsepol`: already configured in arm64

## profiles: arm64 accept_keywords

Clean up unnecessary ebuilds from arm64 accept_keywords like below:

* `app-arch/bzip2` 1.0.6-r12 is already stable.
* `app-crypt/mit-krb5` 1.19.2 is already stable.
* `app-emulation/open-vmdk` 1.0 is not needed by arm64.
* `app-eselect/eselect-rust` is already stable.
* `dev-lang/perl` 5.34.0-r2 is already stable.
* `dev-libs/ding-libs` 0.4.0 is not needed by arm64.
* `dev-libs/elfutils` 0.177 is already stable.
* `dev-libs/libpcre2` 10.34 is already stable.
* `dev-libs/libpcre` 8.44 is already stable.
* `dev-libs/libintl-perl` 1.280.0 is already stable.
* `dev-util/meson` 0.57.2 is already stable.
* `dev-util/re2c` 2.0.3 is already stable.
* `net-analyzer/tcpdump` 4.9.3 is already stable.
* `net-dns/bind-tools` 9.16.6 is already stable.
* `net-dns/dnsmasq` 2.85 is already stable.
* `net-firewall/ebtables` 2.0.11-r3 is already stable.
* `net-libs/libmicrohttpd`: move to base.
* `net-libs/libnfnetlink` 1.0.1 is already stable.
* `net-libs/libnftnl` 1.2.0-r1 is already stable.
* `net-nds/openldap` 2.4.57 is already stable.
* `sys-apps/checkpolicy` is already enabled in base.
* `sys-fs/btrfs-progs` 4.10.2 is not needed by arm64.
* `sys-libs/binutils-libs` 2.36.1-r2 is already stable.
* `virtual/perl-File-Path` 2.130.0 is already stable.
* `virtual/cdrtools` is not needed by arm64.

Add the following ebuilds to arm64 accept_keywords like below:

* `app-misc/jq` 1.6-r3: move from base
* `cross-aarch64-cros-linux-gnu/gcc` 9.3.0-r1: move from base
* `net-misc/curl` 7.79.1: move from base
* `sec-policy/selinux-base` 2.20200818-r2: move from base
* `sec-policy/selinux-base-policy` 2.20200818-r2: move from base
* `sec-policy/selinux-unconfined` 2.20200818-r2: move from base
* `sec-policy/selinux-virt` 2.20200818-r2: move from base
* `sys-apps/checkpolicy` 3.1: move from base
* `sys-apps/kexec-tools` 2.0.17-r1 is needed by arm64
* `sys-firmware/edk2-ovmf` 201905: move from base
* `sys-process/tini` 0.18.0: move from base

## profiles: sdk accept_keywords

Delete `dev-perl/Parse-Yapp`, as 1.210.0 is already stable.
Move `app-crypt/efitools` from base to sdk.

## profiles: systemd feature

Delete `net-libs/libmicrohttpd`, as 0.9.52 is already stable.
Delete `virtual/udev`, as 217 is already stable.

## coreos-devel/sdk-depends

Now that we delete spidermonkey from portage-stable completely, we can delete autoconf 2.1 as well.

====

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/235 .

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4074/cldsv