### PR TITLE
*: replace git:// with https:// for Github URLs

### DIFF
--- a/app-emulation/docker/docker-1.12.6-r8.ebuild
+++ b/app-emulation/docker/docker-1.12.6-r8.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 
 CROS_WORKON_PROJECT="flatcar-linux/docker"
 CROS_WORKON_LOCALNAME="docker"
-CROS_WORKON_REPO="git://github.com"
+CROS_WORKON_REPO="https://github.com"
 COREOS_GO_VERSION="go1.7"
 
 CROS_WORKON_COMMIT="d9ad3fcd5cfb3f72ea60d08d540a350b17b7b035" # coreos-1.12.6

--- a/app-emulation/docker/docker-17.03.2-r1.ebuild
+++ b/app-emulation/docker/docker-17.03.2-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 CROS_WORKON_PROJECT="flatcar-linux/docker"
 CROS_WORKON_LOCALNAME="docker"
-CROS_WORKON_REPO="git://github.com"
+CROS_WORKON_REPO="https://github.com"
 COREOS_GO_VERSION="go1.7"
 
 if [[ ${PV} == *9999 ]]; then

--- a/app-emulation/rkt/rkt-9999.ebuild
+++ b/app-emulation/rkt/rkt-9999.ebuild
@@ -13,7 +13,7 @@ inherit cros-workon coreos-go-depend
 
 CROS_WORKON_PROJECT="rkt/rkt"
 CROS_WORKON_LOCALNAME="rkt"
-CROS_WORKON_REPO="git://github.com"
+CROS_WORKON_REPO="https://github.com"
 
 if [[ "${PV}" == "9999" ]]; then
 	KEYWORDS="~amd64 ~arm64"

--- a/coreos-base/cros-devutils/cros-devutils-9999.ebuild
+++ b/coreos-base/cros-devutils/cros-devutils-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="4"
 CROS_WORKON_PROJECT="flatcar-linux/dev-util"
-CROS_WORKON_REPO="git://github.com"
+CROS_WORKON_REPO="https://github.com"
 CROS_WORKON_LOCALNAME="dev"
 CROS_WORKON_LOCALDIR="src/platform"
 


### PR DESCRIPTION
We need to fix more URLs in LTS 2605, including `docker`, `rkt`, and `cros-devutils`.
