### PR TITLE
Revert back to git:// URLs

### DIFF
--- a/app-admin/locksmith/locksmith-9999.ebuild
+++ b/app-admin/locksmith/locksmith-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/locksmith"
 CROS_WORKON_LOCALNAME="locksmith"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/flatcar-linux/locksmith"
 inherit cros-workon systemd coreos-go
 

--- a/app-admin/mayday/mayday-9999.ebuild
+++ b/app-admin/mayday/mayday-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/mayday"
 CROS_WORKON_LOCALNAME="mayday"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/mayday"
 inherit coreos-go cros-workon
 

--- a/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild
+++ b/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="kinvolk/sdnotify-proxy"
 CROS_WORKON_LOCALNAME="sdnotify-proxy"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/sdnotify-proxy"
 COREOS_GO_GO111MODULE="off"
 inherit coreos-go cros-workon

--- a/app-admin/toolbox/toolbox-9999.ebuild
+++ b/app-admin/toolbox/toolbox-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/toolbox"
 CROS_WORKON_LOCALNAME="toolbox"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"

--- a/app-admin/updateservicectl/updateservicectl-9999.ebuild
+++ b/app-admin/updateservicectl/updateservicectl-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="kinvolk/updateservicectl"
 CROS_WORKON_LOCALNAME="updateservicectl"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/kinvolk/updateservicectl"
 COREOS_GO_GO111MODULE="on"
 inherit cros-workon coreos-go

--- a/app-arch/torcx/torcx-9999.ebuild
+++ b/app-arch/torcx/torcx-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/torcx"
 CROS_WORKON_LOCALNAME="torcx"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/flatcar-linux/torcx"
 COREOS_GO_GO111MODULE="off"
 

--- a/app-crypt/go-tspi/go-tspi-9999.ebuild
+++ b/app-crypt/go-tspi/go-tspi-9999.ebuild
@@ -3,7 +3,7 @@ EAPI=7
 inherit coreos-go eutils git-r3 systemd
 COREOS_GO_PACKAGE="github.com/coreos/go-tspi"
 COREOS_GO_GO111MODULE="off"
-EGIT_REPO_URI="https://github.com/coreos/go-tspi.git"
+EGIT_REPO_URI="git://github.com/coreos/go-tspi.git"
 
 if [[ "${PV}" == 9999 ]]; then
         KEYWORDS="~amd64 ~arm64"

--- a/app-emulation/acbuild/acbuild-9999.ebuild
+++ b/app-emulation/acbuild/acbuild-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 CROS_WORKON_PROJECT="appc/acbuild"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 CROS_WORKON_LOCALNAME="appc-acbuild"
 COREOS_GO_PACKAGE="github.com/appc/acbuild"
 COREOS_GO_GO111MODULE="off"

--- a/app-emulation/actool/actool-9999.ebuild
+++ b/app-emulation/actool/actool-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 CROS_WORKON_PROJECT="appc/spec"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 CROS_WORKON_LOCALNAME="appc-spec"
 COREOS_GO_PACKAGE="github.com/appc/spec"
 COREOS_GO_GO111MODULE="off"

--- a/coreos-base/afterburn/afterburn-9999.ebuild
+++ b/coreos-base/afterburn/afterburn-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 CROS_WORKON_PROJECT="flatcar-linux/afterburn"
 CROS_WORKON_LOCALNAME="afterburn"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ ${PV} == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"

--- a/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/coreos-cloudinit"
 CROS_WORKON_LOCALNAME="coreos-cloudinit"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/coreos-cloudinit"
 COREOS_GO_GO111MODULE="off"
 inherit cros-workon systemd toolchain-funcs udev coreos-go

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -5,7 +5,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/init"
 CROS_WORKON_LOCALNAME="init"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/coreos-base/emerge-gitclone/emerge-gitclone-9999.ebuild
+++ b/coreos-base/emerge-gitclone/emerge-gitclone-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 CROS_WORKON_PROJECT="kinvolk/flatcar-dev-util"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 CROS_WORKON_LOCALNAME="dev"
 CROS_WORKON_LOCALDIR="src/platform"
 

--- a/coreos-base/nova-agent-watcher/nova-agent-watcher-9999.ebuild
+++ b/coreos-base/nova-agent-watcher/nova-agent-watcher-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="coreos/nova-agent-watcher"
 CROS_WORKON_LOCALNAME="nova-agent-watcher"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/nova-agent-watcher"
 COREOS_GO_GO111MODULE="off"
 inherit cros-workon systemd coreos-go

--- a/coreos-base/update-ssh-keys/update-ssh-keys-9999.ebuild
+++ b/coreos-base/update-ssh-keys/update-ssh-keys-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 CROS_WORKON_PROJECT="flatcar-linux/update-ssh-keys"
 CROS_WORKON_LOCALNAME="update-ssh-keys"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ ${PV} == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"

--- a/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/coreos-base/update_engine/update_engine-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/update_engine"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/coreos-devel/fero-client/fero-client-9999.ebuild
+++ b/coreos-devel/fero-client/fero-client-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 CROS_WORKON_PROJECT="coreos/fero"
 CROS_WORKON_LOCALNAME="fero"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ ${PV} == 9999 ]]; then
 	KEYWORDS="~amd64"

--- a/coreos-devel/mantle/mantle-9999.ebuild
+++ b/coreos-devel/mantle/mantle-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/mantle"
 CROS_WORKON_LOCALNAME="mantle"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/mantle"
 COREOS_GO_MOD="vendor"
 

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -15,7 +15,7 @@ app-misc/editor-wrapper *
 =dev-lang/nasm-2.14.02 *
 =dev-lang/perl-5.24.1-r2 ~arm64
 =dev-lang/swig-3.0.12 ~arm64
-=dev-lang/yasm-1.3.0-r1 ~arm64
+=dev-lang/yasm-1.3.0 ~arm64
 =dev-libs/ding-libs-0.4.0 **
 =dev-libs/elfutils-0.169-r1 ~arm64
 =dev-libs/libassuan-2.5.1 ~arm64

--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/baselayout"
 CROS_WORKON_LOCALNAME="baselayout"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/ignition"
 CROS_WORKON_LOCALNAME="ignition"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/ignition"
 COREOS_GO_GO111MODULE="off"
 inherit coreos-go cros-workon systemd udev

--- a/sys-apps/seismograph/seismograph-9999.ebuild
+++ b/sys-apps/seismograph/seismograph-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/seismograph"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/sys-boot/grub/grub-9999.ebuild
+++ b/sys-boot/grub/grub-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 
 CROS_WORKON_PROJECT="flatcar-linux/grub"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 GRUB_AUTOGEN=1  # We start from Git, so always autogen.
 
 if [[ ${PV} == 9999 ]]; then

--- a/sys-boot/shim/shim-9999.ebuild
+++ b/sys-boot/shim/shim-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/shim"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/bootengine"
 CROS_WORKON_LOCALNAME="bootengine"
 CROS_WORKON_OUTOFTREE_BUILD=1
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/sys-libs/nss-usrfiles/nss-usrfiles-9999.ebuild
+++ b/sys-libs/nss-usrfiles/nss-usrfiles-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 CROS_WORKON_PROJECT="flatcar-linux/nss-altfiles"
 CROS_WORKON_LOCALNAME="nss-altfiles"
-CROS_WORKON_REPO="https://github.com"
+CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"


### PR DESCRIPTION
This PR reverts https://github.com/flatcar-linux/coreos-overlay/pull/1386, because the PR caused the SDK stage2 build to fail due to missing ssl in libcurl.

```
git fetch https://github.com/flatcar-linux/baselayout.git --prune +refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/* +refs/notes/*:refs/notes/* +refs/pull/*/head:refs/pull/* +HEAD:refs/git-r3/HEAD
fatal: unable to access 'https://github.com/flatcar-linux/baselayout.git/': Protocol "https" not supported or disabled in libcurl
```

Revert until we can fix the issue correctly in the future.

With https://github.com/flatcar-linux/portage-stable/pull/239.