### PR TITLE
profiles: Changes related to package updates in portage-stable (getting rid of EAPI 3)

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -16,7 +16,6 @@ app-misc/editor-wrapper *
 # needed by arm64-native SDK
 =dev-lang/nasm-2.14.02 *
 
-=dev-lang/swig-3.0.12 ~arm64
 =dev-lang/yasm-1.3.0-r1 ~arm64
 =dev-libs/libassuan-2.5.1 ~arm64
 =dev-libs/libevent-2.1.8 ~arm64

--- a/profiles/coreos/targets/generic/package.provided
+++ b/profiles/coreos/targets/generic/package.provided
@@ -8,8 +8,7 @@
 app-eselect/eselect-pinentry-0.7
 
 # pulled in by app-editors/vim
-app-admin/eselect-vi-1.1.5
-app-eselect/eselect-vi-1.1.7-r1
+app-eselect/eselect-vi-1.2
 
 # pulled in by net-firewall/iptables
 app-eselect/eselect-iptables-20200508


### PR DESCRIPTION
Should be merged with https://github.com/flatcar-linux/portage-stable/pull/242.

CI passed: http://localhost:9091/job/os/job/manifest/4109/cldsv/