### PR TITLE
profiles: add missing arm64 sdk keywords

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -2,6 +2,7 @@
 # Keep these in alphabetical order.
 
 # needed by arm64-native SDK
+=app-emulation/open-vmdk-1.0 *
 app-misc/editor-wrapper *
 
 =app-misc/jq-1.6-r3 ~arm64
@@ -130,6 +131,7 @@ sys-apps/debianutils *
 =sys-libs/libsepol-3.1 ~arm64
 =sys-power/iasl-20161222 ~arm64
 =sys-process/tini-0.18.0 ~arm64
+=virtual/cdrtools-0 *
 =virtual/krb5-0-r1 ~arm64
 =virtual/libusb-1-r2 ~arm64
 =x11-libs/pixman-0.32.8 ~arm64


### PR DESCRIPTION
# profiles: add missing arm64 sdk keywords
The recent keyword cleanup removed two keywords that are necessary to
bootstrap an arm64 sdk: open-vmdk and virtual/cdrtools. Restore them.

## How to use

No real great way, because we don't have automated sdk bootstrap for arm64 yet.

## Testing done

Tested that `./boostrap_sdk stage4` starts instead of failing due to unmet dependencies.
