### PR TITLE
Upgrade net-libs/libmicrohttpd to 0.9.73

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -34,8 +34,6 @@ dev-util/checkbashisms
 
 =net-libs/gnutls-3.7.1 ~amd64 ~arm64
 
-=net-libs/libmicrohttpd-0.9.55 ~amd64 ~arm64
-
 =net-misc/openssh-8.7_p1-r1 ~amd64 ~arm64
 
 =net-misc/rsync-3.2.3-r5 ~amd64 ~arm64


### PR DESCRIPTION
Signed-off-by: ArkaprabhaChakraborty <chakrabortyarkaprabha998@gmail.com>

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/243. 

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4221/cldsv