### PR TITLE
profiles: exclude unicode USE flag from app-editors/nano

### DIFF
--- a/profiles/coreos/base/package.use.mask
+++ b/profiles/coreos/base/package.use.mask
@@ -15,3 +15,10 @@ sys-boot/syslinux perl
 
 # not needed, problems building with GCC 7.3.0
 sys-libs/ncurses cxx
+
+# app-editors/nano with `USE=unicode` results in build failures in SDK
+# stage1, because ncurses >= 6.2_p20210619 which does not have the USE
+# flag at all.
+# To fix that, exclude the unicode USE flag from packages.use.force list,
+# which is defined in portage-stable.
+app-editors/nano unicode


### PR DESCRIPTION
`app-editors/nano` with `USE=unicode` results in build failures in SDK stage1, because ncurses >= 6.2_p20210619 which does not have the USE flag at all.

To fix that, exclude the unicode USE flag from `packages.use.force` list, which is defined in portage-stable.
We can do that by setting the flag in `package.use.mask`.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/245.

## Testing done

CI passed http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4128/cldsv
(with specific SEED_SDK_{OVERLAY,PORTAGE}_GITREF values)