### PR TITLE
profiles: Changes related to package updates in portage-stable (getting rid of EAPI 4)

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -3,7 +3,6 @@
 
 # needed by arm64-native SDK
 =app-emulation/open-vmdk-1.0 *
-app-misc/editor-wrapper *
 
 =app-misc/jq-1.6-r3 ~arm64
 ~app-arch/pbzip2-1.1.12 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -52,9 +52,6 @@ dev-util/patchelf *
 sys-apps/dtc ~arm64
 =sys-apps/checkpolicy-3.1 ~arm64
 
-# needed by arm64-native SDK
-sys-apps/debianutils *
-
 # needed to force enable lshw for arm64
 =sys-apps/lshw-02.17b-r2 **
 

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -61,9 +61,6 @@ dev-util/patchelf *
 =sys-apps/sandbox-2.12 ~arm64
 =sys-apps/semodule-utils-3.1 ~arm64
 
-# needed to force enable smartmontools for arm64
-=sys-apps/smartmontools-6.4 **
-
 =sys-block/parted-3.2-r1 ~arm64
 =sys-block/thin-provisioning-tools-0.7.0 ~arm64
 =sys-boot/efibootmgr-15 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -49,7 +49,6 @@ dev-util/patchelf *
 =sec-policy/selinux-base-policy-2.20200818-r2 ~arm64
 =sec-policy/selinux-unconfined-2.20200818-r2 ~arm64
 =sec-policy/selinux-virt-2.20200818-r2 ~arm64
-sys-apps/dtc ~arm64
 =sys-apps/checkpolicy-3.1 ~arm64
 
 # needed to force enable lshw for arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -8,7 +8,6 @@
 ~app-arch/pbzip2-1.1.12 ~arm64
 =app-arch/pigz-2.3.3 ~arm64
 =dev-cpp/gflags-2.2.0 ~arm64
-=dev-cpp/glog-0.3.4-r1 ~arm64
 =dev-embedded/u-boot-tools-2021.04_rc2 ~arm64
 
 # needed by arm64-native SDK

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -51,9 +51,6 @@ dev-util/patchelf *
 =sec-policy/selinux-virt-2.20200818-r2 ~arm64
 =sys-apps/checkpolicy-3.1 ~arm64
 
-# needed to force enable lshw for arm64
-=sys-apps/lshw-02.17b-r2 **
-
 =sys-apps/man-db-2.7.6.1-r2 ~arm64
 =sys-apps/policycoreutils-3.1-r3 ~arm64
 =sys-apps/kexec-tools-2.0.17-r1 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -55,9 +55,6 @@ dev-util/patchelf *
 =sys-apps/policycoreutils-3.1-r3 ~arm64
 =sys-apps/kexec-tools-2.0.17-r1 ~arm64
 
-# needed by arm64-native SDK
-=sys-apps/pv-1.3.4 *
-
 # needed to force enable rng-tools for arm64
 =sys-apps/rng-tools-5-r2 **
 

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -64,7 +64,6 @@ dev-util/patchelf *
 =sys-block/parted-3.2-r1 ~arm64
 =sys-block/thin-provisioning-tools-0.7.0 ~arm64
 =sys-boot/efibootmgr-15 ~arm64
-=sys-boot/gnu-efi-3.0.3 ~arm64
 
 # needed to force enable ipvsadm for arm64
 =sys-cluster/ipvsadm-1.27-r1 **

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -30,7 +30,6 @@ dev-util/checkbashisms *
 # needed by arm64-native SDK
 dev-util/patchelf *
 
-=net-dialup/minicom-2.7.1 ~arm64
 =net-dns/c-ares-1.17.2 ~arm64
 =net-firewall/conntrack-tools-1.4.5 ~arm64
 =net-firewall/ipset-6.29 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -32,7 +32,6 @@ dev-util/patchelf *
 
 =net-dns/c-ares-1.17.2 ~arm64
 =net-firewall/conntrack-tools-1.4.5 ~arm64
-=net-firewall/ipset-6.29 ~arm64
 =net-libs/http-parser-2.6.2 ~arm64
 =net-libs/libnetfilter_conntrack-1.0.8 ~arm64
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64

--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -12,7 +12,7 @@ net-analyzer/tcpdump	-chroot
 net-misc/dhcp	        -server
 net-misc/iperf		threads
 net-misc/ntp            caps
-sys-apps/smartmontools	minimal
+sys-apps/smartmontools	-daemon -update-drivedb -systemd
 sys-block/parted        device-mapper
 sys-fs/lvm2		-readline
 sys-libs/ncurses	minimal


### PR DESCRIPTION
Should be merged together with https://github.com/flatcar-linux/portage-stable/pull/246.

CI: http://localhost:9091/job/os/job/manifest/4408/cldsv/