### PR TITLE
dev-embedded/u-boot-tools: Update to v2021.04_rc2 for arm64

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -11,7 +11,7 @@ app-misc/editor-wrapper *
 =cross-aarch64-cros-linux-gnu/gcc-9.3.0-r1 ~arm64
 =dev-cpp/gflags-2.2.0 ~arm64
 =dev-cpp/glog-0.3.4-r1 ~arm64
-=dev-embedded/u-boot-tools-2019.10 ~arm64
+=dev-embedded/u-boot-tools-2021.04_rc2 ~arm64
 
 # needed by arm64-native SDK
 =dev-lang/nasm-2.14.02 *


### PR DESCRIPTION
# dev-embedded/u-boot-tools: Update to v2021.04_rc2 for arm64

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4148/cldsv