### PR TITLE
.github: add Github Actions for ca-certificates

### DIFF
--- a/.github/workflows/cacerts-apply-patch.sh
+++ b/.github/workflows/cacerts-apply-patch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+UPDATE_NEEDED=1
+
+. .github/workflows/common.sh
+
+prepare_git_repo
+
+if ! checkout_branches "${VERSION_NEW}-${TARGET}"; then
+  UPDATE_NEEDED=0
+  exit 0
+fi
+
+pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
+
+# Parse the Manifest file for already present source files and keep the latest version in the current series
+VERSION_OLD=$(sed -n "s/^DIST nss-\([0-9]*\.[0-9]*\).*$/\1/p" app-misc/ca-certificates/Manifest | sort -ruV | head -n1)
+if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
+  echo "already the latest ca-certificates, nothing to do"
+  UPDATE_NEEDED=0
+  exit 0
+fi
+
+EBUILD_FILENAME=$(get_ebuild_filename "app-misc" "ca-certificates" "${VERSION_OLD}")
+git mv "${EBUILD_FILENAME}" "app-misc/ca-certificates/ca-certificates-${VERSION_NEW}.ebuild"
+
+popd >/dev/null || exit
+
+generate_patches app-misc ca-certificates ca-certificates
+
+apply_patches
+
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
+echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"

--- a/.github/workflows/cacerts-releases-alpha.yml
+++ b/.github/workflows/cacerts-releases-alpha.yml
@@ -1,0 +1,48 @@
+name: Get the latest ca-certificates release for the Alpha maintenance branch
+on:
+  schedule:
+    - cron:  '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  get-cacerts-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest ca-certificates release
+        id: fetch-latest-release
+        env:
+          CHANNEL: alpha
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/nss-dev/nss
+          versionMaintenance=$(git -C nss ls-remote --tags origin | cut -f2 | sed -n "s/refs\/tags\/NSS_\([0-9]_[0-9_]*\).*_RTM$/\1/p" | sort -s -t_ -k1,1 -k2,2n -k3,3n | tr '_' '.' | tail -n1)
+          rm -rf nss
+          maintenanceBranch=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/version.txt" | grep -m 1 FLATCAR_BUILD= | cut -d = -f 2-)
+          echo ::set-output name=BASE_BRANCH_MAINTENANCE::$(echo flatcar-${maintenanceBranch})
+          echo ::set-output name=VERSION_MAINTENANCE::$(echo ${versionMaintenance})
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for maintenance branch
+        id: apply-patch-maintenance
+        env:
+          TARGET: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+        run: .github/workflows/cacerts-apply-patch.sh
+      - name: Create pull request for maintenance branch
+        uses: peter-evans/create-pull-request@v3
+        if: steps.apply-patch-maintenance.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          branch: cacerts-${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}-${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          commit-message: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          body: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          labels: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}

--- a/.github/workflows/cacerts-releases-beta.yml
+++ b/.github/workflows/cacerts-releases-beta.yml
@@ -1,0 +1,48 @@
+name: Get the latest ca-certificates release for the Beta maintenance branch
+on:
+  schedule:
+    - cron:  '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  get-cacerts-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest ca-certificates release
+        id: fetch-latest-release
+        env:
+          CHANNEL: beta
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/nss-dev/nss
+          versionMaintenance=$(git -C nss ls-remote --tags origin | cut -f2 | sed -n "s/refs\/tags\/NSS_\([0-9]_[0-9_]*\).*_RTM$/\1/p" | sort -s -t_ -k1,1 -k2,2n -k3,3n | tr '_' '.' | tail -n1)
+          rm -rf nss
+          maintenanceBranch=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/version.txt" | grep -m 1 FLATCAR_BUILD= | cut -d = -f 2-)
+          echo ::set-output name=BASE_BRANCH_MAINTENANCE::$(echo flatcar-${maintenanceBranch})
+          echo ::set-output name=VERSION_MAINTENANCE::$(echo ${versionMaintenance})
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for maintenance branch
+        id: apply-patch-maintenance
+        env:
+          TARGET: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+        run: .github/workflows/cacerts-apply-patch.sh
+      - name: Create pull request for maintenance branch
+        uses: peter-evans/create-pull-request@v3
+        if: steps.apply-patch-maintenance.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          branch: cacerts-${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}-${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          commit-message: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          body: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          labels: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}

--- a/.github/workflows/cacerts-releases-lts-2021.yml
+++ b/.github/workflows/cacerts-releases-lts-2021.yml
@@ -1,0 +1,46 @@
+name: Get the latest ca-certificates release for the LTS-2021 maintenance branch
+on:
+  schedule:
+    - cron:  '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  get-cacerts-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest ca-certificates release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/nss-dev/nss
+          versionMaintenance=$(git -C nss ls-remote --tags origin | cut -f2 | sed -n "s/refs\/tags\/NSS_\([0-9]_[0-9_]*\).*_RTM$/\1/p" | sort -s -t_ -k1,1 -k2,2n -k3,3n | tr '_' '.' | tail -n1)
+          rm -rf nss
+          maintenanceBranch=2605
+          echo ::set-output name=BASE_BRANCH_MAINTENANCE::$(echo flatcar-lts-${maintenanceBranch})
+          echo ::set-output name=VERSION_MAINTENANCE::$(echo ${versionMaintenance})
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for maintenance branch
+        id: apply-patch-maintenance
+        env:
+          TARGET: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+        run: .github/workflows/cacerts-apply-patch.sh
+      - name: Create pull request for maintenance branch
+        uses: peter-evans/create-pull-request@v3
+        if: steps.apply-patch-maintenance.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          branch: cacerts-${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}-${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          commit-message: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          body: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          labels: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}

--- a/.github/workflows/cacerts-releases-main.yaml
+++ b/.github/workflows/cacerts-releases-main.yaml
@@ -1,0 +1,45 @@
+name: Get the latest ca-certificates release for main
+on:
+  schedule:
+    - cron:  '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  get-cacerts-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest ca-certificates release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/nss-dev/nss
+          versionMain=$(git -C nss ls-remote --tags origin | cut -f2 | sed -n "s/refs\/tags\/NSS_\([0-9]_[0-9_]*\).*_RTM$/\1/p" | sort -s -t_ -k1,1 -k2,2n -k3,3n | tail -n1)
+          rm -rf nss
+          echo ::set-output name=BASE_BRANCH_MAIN::main
+          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for main
+        id: apply-patch-main
+        env:
+          TARGET: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+        run: .github/workflows/cacerts-apply-patch.sh
+      - name: Create pull request for main
+        uses: peter-evans/create-pull-request@v3
+        if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          branch: cacerts-${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}-${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade ca-certificates in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          commit-message: Upgrade ca-certificates in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          body: Upgrade ca-certificates in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          labels: main

--- a/.github/workflows/cacerts-releases-stable.yml
+++ b/.github/workflows/cacerts-releases-stable.yml
@@ -1,0 +1,48 @@
+name: Get the latest ca-certificates release for the Stable maintenance branch
+on:
+  schedule:
+    - cron:  '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  get-cacerts-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest ca-certificates release
+        id: fetch-latest-release
+        env:
+          CHANNEL: stable
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/nss-dev/nss
+          versionMaintenance=$(git -C nss ls-remote --tags origin | cut -f2 | sed -n "s/refs\/tags\/NSS_\([0-9]_[0-9_]*\).*_RTM$/\1/p" | sort -s -t_ -k1,1 -k2,2n -k3,3n | tr '_' '.' | tail -n1)
+          rm -rf nss
+          maintenanceBranch=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/version.txt" | grep -m 1 FLATCAR_BUILD= | cut -d = -f 2-)
+          echo ::set-output name=BASE_BRANCH_MAINTENANCE::$(echo flatcar-${maintenanceBranch})
+          echo ::set-output name=VERSION_MAINTENANCE::$(echo ${versionMaintenance})
+      - name: Set up Flatcar SDK
+        id: setup-flatcar-sdk
+        run: .github/workflows/setup-flatcar-sdk.sh
+      - name: Apply patch for maintenance branch
+        id: apply-patch-maintenance
+        env:
+          TARGET: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+        run: .github/workflows/cacerts-apply-patch.sh
+      - name: Create pull request for maintenance branch
+        uses: peter-evans/create-pull-request@v3
+        if: steps.apply-patch-maintenance.outputs.UPDATE_NEEDED == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          branch: cacerts-${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}-${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          commit-message: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          body: Upgrade ca-certificates in maintenance branch from ${{ steps.apply-patch-maintenance.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          labels: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}


### PR DESCRIPTION
Automatically update `app-misc/ca-certificates`, a derivative of [nss](https://hg.mozilla.org/projects/nss).
To make things easier, we simply check for new releases on its [Github mirror](https://github.com/nss-dev/nss).
When the new latest tag is found, simply bump the version of ca-certificates ebuild.

Fixes https://github.com/flatcar-linux/Flatcar/issues/533.