### PR TITLE
sec-policy/selinux-base-policy: add capability to unlabeled_t

### DIFF
--- a/sec-policy/selinux-base-policy/files/unlabeled.patch
+++ b/sec-policy/selinux-base-policy/files/unlabeled.patch
@@ -1,0 +1,11 @@
+index 7c60eda2c..736187b7a 100644
+--- refpolicy/policy/modules/kernel/kernel.te
++++ refpolicy/policy/modules/kernel/kernel.te
+@@ -191,6 +191,7 @@ genfscon proc /sys/dev gen_context(system_u:object_r:sysctl_dev_t,s0)
+ type unlabeled_t;
+ kernel_rootfs_mountpoint(unlabeled_t)
+ fs_associate(unlabeled_t)
++fs_associate_tmpfs(unlabeled_t)
+ sid file gen_context(system_u:object_r:unlabeled_t,s0)
+ sid unlabeled gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
+ neverallow * unlabeled_t:file entrypoint;

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20200818-r2.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20200818-r2.ebuild
@@ -39,6 +39,10 @@ PATCHES=(
 	"${FILESDIR}/init.patch"
 	"${FILESDIR}/locallogin.patch"
 	"${FILESDIR}/logging.patch"
+	# this patch is required to prevent `torcx-generator`
+	# to fail if SELinux is enforced in early boot.
+	# It can be removed once we drop torcx support.
+	"${FILESDIR}/unlabeled.patch"
 )
 
 # Code entirely copied from selinux-eclass (cannot inherit due to dependency on


### PR DESCRIPTION
with this patch, we allow `unlabeled_t` to associate to tmpfs
filesystem.
It aims to solve the AVC we have with `torcx` with the
`torcx-generator`:
```
Nov 15 09:45:43 localhost audit[688]: AVC avc: denied { associate } for pid=688 comm="torcx-generator" name="docker" dev="tmpfs" ino=2 scontext=system_u:object_r:unlabeled_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0
```

It has been not been caught earlier because it occurs
when the system boots with `SELinux` in `enforcing` mode.

This denial was preventing torcx to finish correctly its setup and so
Docker was not able to start.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

It has been reported in https://github.com/flatcar-linux/Flatcar/issues/544

CI :large_blue_circle: : http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4177/cldsv/

Tested on built image with SELinux enabled early in the boot:
```
$ sestatus
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             mcs
Current mode:                   enforcing
Mode from config file:          enforcing
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      33
$ docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
$ journalctl _TRANSPORT=audit | grep -i torcx
```

While on current stable with the same config:

```
$ sestatus
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             mcs
Current mode:                   enforcing
Mode from config file:          enforcing
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      33
$ journalctl _TRANSPORT=audit | grep -i torcx
Nov 18 09:30:32 localhost audit[687]: AVC avc:  denied  { associate } for  pid=687 comm="torcx-generator" name="docker" dev="tmpfs" ino=2 scontext=system_u:object_r:unlabeled_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0
$ docker ps
The program docker is managed by torcx, which did not run.
```

_NOTE_: Mantle logic is now implemented in order to enable `SELinux` in `enforcing` as soon as possible: https://github.com/flatcar-linux/mantle/pull/252 

