### PR TITLE
profiles: accept keywords for rsync 3.2.3-r5

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -38,6 +38,8 @@ dev-util/checkbashisms
 
 =net-misc/openssh-8.7_p1-r1 ~amd64 ~arm64
 
+=net-misc/rsync-3.2.3-r5 ~amd64 ~arm64
+
 # To address security issues like CVE-2021-31879, we need to accept
 # keywords for wget 1.21.2.
 =net-misc/wget-1.21.2 ~amd64 ~arm64


### PR DESCRIPTION
To be able to update rsync to 3.2.3-r5, we need to accept keywords for both `~amd64` and `~arm64`.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/249 .

## Testing done

CI passed except SELinux failures: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4187/cldsv