### PR TITLE
app-admin/logrotate: Correct downstream changes to take effect

### DIFF
--- a/app-admin/logrotate/files/logrotate.service
+++ b/app-admin/logrotate/files/logrotate.service
@@ -2,4 +2,4 @@
 Description=Rotate and Compress System Logs
 
 [Service]
-ExecStart=/usr/sbin/logrotate /usr/share/logrotate/logrotate.conf
+ExecStart=/usr/bin/logrotate /usr/share/logrotate/logrotate.conf

--- a/app-admin/logrotate/logrotate-3.18.1-r1.ebuild
+++ b/app-admin/logrotate/logrotate-3.18.1-r1.ebuild
@@ -64,12 +64,13 @@ src_install() {
 	doman logrotate.8
 	dodoc ChangeLog.md
 
-	insinto /etc
+	insinto /usr/share/logrotate
 	doins "${FILESDIR}"/logrotate.conf
 
 	use cron && install_cron_file
 
-	systemd_dounit examples/logrotate.{service,timer}
+	systemd_dounit examples/logrotate.timer
+	systemd_dounit "${FILESDIR}"/logrotate.service
 	systemd_enable_service multi-user.target logrotate.timer
 	newtmpfiles "${FILESDIR}"/${PN}.tmpfiles ${PN}.conf
 


### PR DESCRIPTION
By accident the upstream files from the example folder got used,
instead of the downstream files that were added in the files/ folder.
Also, the configuration file didn't get installed.

Use the right paths to install the downstream files.

## How to use

Check that logrotate doesn't fail
Pick for flatcar-3066

## Testing done

Booted https://bucket.release.flatcar-linux.net/flatcar-jenkins/developer/developer/boards/amd64-usr/2021.11.22+dev-flatcar-master-4222/flatcar_production_image.bin.bz2
and ran `sudo systemctl start logrotate.service` and `systemctl status logrotate.service` and it worked: `Process: 958 ExecStart=/usr/bin/logrotate /usr/share/logrotate/logrotate.conf (code=exited, status=0/SUCCESS)`