### PR TITLE
app-admin/etcd-wrapper: remove `ETCD_NAME`

### DIFF
--- a/app-admin/etcd-wrapper/files/etcd-wrapper
+++ b/app-admin/etcd-wrapper/files/etcd-wrapper
@@ -4,6 +4,17 @@
 # ExecStart here.
 set -e
 
+# Since etcd/v3 we can't use both `--name` and `ETCD_NAME` at the same time.
+# We parse the etcd command line options to find a `--name/-name` flag if we found one,
+# we unset the `ETCD_NAME` to not conflict with it.
+for f in "${@}"; do
+    if [[ $f =~ ^-?-name=? ]]; then
+        unset ETCD_NAME
+        break
+    fi
+done
+
+
 # Do not pass ETCD_DATA_DIR through to the container. The default path,
 # /var/lib/etcd is always used inside the container.
 etcd_data_dir="${ETCD_DATA_DIR}"


### PR DESCRIPTION
`etcd` node's name was defined by `ETCD_NAME`, from `etcd/v3` the server
can't be started with both `ETCD_NAME` and `--name` supplied.

Which leads to three cases:
* `etcd-member.service` starts without further configuration, no issue
since only `ETCD_NAME=%m` is used
* `etcd-member.service` is overrided with a CLC without `name: ` key, no
issue since only `ETCD_NAME=%m` is used
* `etcd-member.service` is overrided with a CLC with a `name: ` key,
there is an issue since in the final service we will have both
`ETCD_NAME=%m` and `--name name-from-clc`

This patch conditionally unset the `ETCD_NAME` in case `--name/-name` is
supplied.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

Closes: https://github.com/flatcar-linux/Flatcar/issues/547

<hr>

CI :large_blue_circle: : http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4237/cldsv/
Kola test: https://github.com/flatcar-linux/mantle/pull/259
