### PR TITLE
profiles: delete unnecessary keywords for gcc

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -9,7 +9,6 @@ app-misc/editor-wrapper *
 ~app-arch/pbzip2-1.1.12 ~arm64
 =app-arch/pigz-2.3.3 ~arm64
 =app-text/asciidoc-8.6.9-r3 ~arm64
-=cross-aarch64-cros-linux-gnu/gcc-9.3.0-r1 ~arm64
 =dev-cpp/gflags-2.2.0 ~arm64
 =dev-cpp/glog-0.3.4-r1 ~arm64
 =dev-embedded/u-boot-tools-2021.04_rc2 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -53,10 +53,7 @@ dev-util/checkbashisms
 # Upgrade to GCC 9.3.0 to support latest glibc builds
 =sys-devel/binutils-2.37_p1 ~amd64 ~arm64
 =sys-devel/gcc-config-1.9.1 ~amd64 ~arm64
-=sys-devel/gcc-8.3.0  ~amd64 ~arm64
-=sys-devel/gcc-9.3.0-r1 ~amd64 ~arm64
 =sys-libs/binutils-libs-2.37_p1 ~amd64 ~arm64
-=cross-x86_64-cros-linux-gnu/gcc-9.3.0-r1 ~amd64
 
 =sys-firmware/sgabios-0.1_pre8-r1 ~amd64 ~arm64
 


### PR DESCRIPTION
Now that gcc 9.4.0 already has stable keywords both amd64 and arm64, we do not need to accept keywords in profiles.
Simply delete.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/252 .

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4238/cldsv

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) - done in https://github.com/flatcar-linux/portage-stable/pull/252
