### PR TITLE
sys-apps/ignition: update golang.org/x/text to 0.3.7

### DIFF
--- a/changelog/security/2021-11-30-CVE-2020-14040.md
+++ b/changelog/security/2021-11-30-CVE-2020-14040.md
@@ -1,0 +1,1 @@
+- [CVE-2020-14040](https://nvd.nist.gov/vuln/detail/CVE-2020-14040)

--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -12,7 +12,7 @@ inherit coreos-go cros-workon systemd udev
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="eda58aa14fd65e19d7f117aaa5fc97e3d995c277" # flatcar-master
+	CROS_WORKON_COMMIT="6d7b4401700c76492c8627030d9dde147f81d5cf" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
Update `golang.org/x/text` to 0.3.7, mainly to address [CVE-2020-14040](https://nvd.nist.gov/vuln/detail/CVE-2020-14040).

Pulls in https://github.com/flatcar-linux/ignition/pull/31

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4270/cldsv

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
