### PR TITLE
app-arch/torcx: Fix wrong reference to Docker 19.03

### DIFF
--- a/app-arch/torcx/files/docker-1.12-no.json
+++ b/app-arch/torcx/files/docker-1.12-no.json
@@ -4,7 +4,7 @@
         "images": [
             {
                 "name": "docker",
-                "reference": "19.03"
+                "reference": "com.coreos.cl"
             }
         ]
     }

--- a/changelog/bugfixes/2021-12-01-torcx-docker-1.12-no-profile.md
+++ b/changelog/bugfixes/2021-12-01-torcx-docker-1.12-no-profile.md
@@ -1,0 +1,1 @@
+- The Torcx profile `docker-1.12-no` got fixed to reference the current Docker version instead of 19.03 which wasn't found on the image, causing Torcx to fail to provide Docker [PR#1456](https://github.com/flatcar-linux/coreos-overlay/pull/1456)


### PR DESCRIPTION
When selecting the docker-1.12-no profile, torcx failed because the
profile looked for 19.03 instead of 20.10.

Make the docker-1.12-no profile identical to the vendor profile so
that we don't have to update it.


## How to use

Check that
```
echo docker-1.12-no | sudo tee /etc/torcx/next-profile
sudo reboot
```
works again.

Backport to Stable, Beta, Alpha.

## Testing done

build scheduled, ran the above test

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
