### PR TITLE
Teach github actions to generate changelog entries

### DIFF
--- a/.github/workflows/cacerts-apply-patch.sh
+++ b/.github/workflows/cacerts-apply-patch.sh
@@ -28,6 +28,11 @@ git mv "${EBUILD_FILENAME}" "app-misc/ca-certificates/ca-certificates-${VERSION_
 
 popd >/dev/null || exit
 
+URLVERSION=$(echo "${VERSION_NEW}" | tr '.' '_')
+URL="https://firefox-source-docs.mozilla.org/security/nss/releases/nss_${URLVERSION}.html"
+
+generate_update_changelog 'ca-certificates' "${VERSION_NEW}" "${URL}" 'ca-certificates'
+
 generate_patches app-misc ca-certificates ca-certificates
 
 apply_patches

--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -64,6 +64,19 @@ function regenerate_manifest() {
   popd || exit
 }
 
+function generate_update_changelog() {
+  local NAME="${1}"
+  local VERSION="${2}"
+  local URL="${3}"
+  local UPDATE_NAME="${4}"
+
+  pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
+  if [[ -d changelog/updates ]]; then
+      echo "- ${NAME} ([${VERSION}](${URL}))" > "changelog/updates/$(date '+%Y-%m-%d')-${UPDATE_NAME}-update.md"
+  fi
+  popd >/dev/null || exit
+}
+
 function generate_patches() {
   CATEGORY_NAME=$1
   PKGNAME_SIMPLE=$2
@@ -78,6 +91,9 @@ function generate_patches() {
   # We can only create the actual commit in the actual source directory, not under the SDK.
   # So create a format-patch, and apply to the actual source.
   git add ${CATEGORY_NAME}/${PKGNAME_SIMPLE}
+  if [[ -d changelog ]]; then
+      git add changelog
+  fi
   for dir in "$@"; do
       git add "${dir}"
   done

--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -32,11 +32,18 @@ function get_ebuild_filename() {
 }
 
 function prepare_git_repo() {
+  local our_remote_url
+
   git config user.name "${BUILDBOT_USERNAME}"
   git config user.email "${BUILDBOT_USEREMAIL}"
   git reset --hard HEAD
   git fetch origin
   git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+  our_remote_url=$(git remote get-url origin)
+
+  # setup overlay repo inside SDK too (be fork friendly)
+  git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" remote add our_remote "${our_remote_url}"
+  git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" fetch our_remote
 }
 
 # caller needs to set pass a parameter as a branch name to be created.
@@ -48,7 +55,7 @@ function checkout_branches() {
   git -C "${SDK_OUTER_SRCDIR}/scripts" checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
   git -C "${SDK_OUTER_SRCDIR}/third_party/portage-stable" checkout -B "${BASE_BRANCH}" "github/${BASE_BRANCH}"
 
-  if git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" show-ref "remotes/github/${TARGET_BRANCH}"; then
+  if git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" show-ref "remotes/our_remote/${TARGET_BRANCH}"; then
     echo "Target branch already exists. exit.";
     return 1
   fi

--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -40,6 +40,10 @@ sed -i "s/containerd-${VERSION_OLD}/containerd-${VERSION_NEW}/g" ${torcxEbuildFi
 
 popd >/dev/null || exit
 
+URL="https://github.com/containerd/containerd/releases/tag/v${VERSION_NEW}"
+
+generate_update_changelog 'containerd' "${VERSION_NEW}" "${URL}" 'containerd'
+
 generate_patches app-emulation containerd Containerd
 
 apply_patches

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -50,7 +50,7 @@ sed -i "s/github.com\/docker\/docker-ce\/blob\/v${VERSION_OLD}/github.com\/docke
 popd >/dev/null || exit
 
 regenerate_manifest app-emulation docker-cli
-generate_patches app-emulation docker Docker
+generate_patches app-emulation docker Docker app-emulation/docker-cli app-torcx/docker app-emulation/docker-runc
 
 apply_patches
 

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -49,6 +49,12 @@ sed -i "s/github.com\/docker\/docker-ce\/blob\/v${VERSION_OLD}/github.com\/docke
 
 popd >/dev/null || exit
 
+# drop all dots
+URLVERSION="${VERSION_NEW//./}"
+URL="https://docs.docker.com/engine/release-notes/#${URLVERSION}"
+
+generate_update_changelog 'Docker' "${VERSION_NEW}" "${URL}" 'docker'
+
 regenerate_manifest app-emulation docker-cli
 generate_patches app-emulation docker Docker app-emulation/docker-cli app-torcx/docker app-emulation/docker-runc
 

--- a/.github/workflows/firmware-apply-patch.sh
+++ b/.github/workflows/firmware-apply-patch.sh
@@ -28,6 +28,10 @@ git mv "${EBUILD_FILENAME}" "sys-kernel/coreos-firmware/coreos-firmware-${VERSIO
 
 popd >/dev/null || exit
 
+URL="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=${VERSION_NEW}"
+
+generate_update_changelog 'Linux Firmware' "${VERSION_NEW}" "${URL}" 'linux-firmware'
+
 generate_patches sys-kernel coreos-firmware "Linux Firmware"
 
 apply_patches

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -32,6 +32,10 @@ git mv "${EBUILD_FILENAME}" "dev-lang/go/go-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 
+URL="https://go.googlesource.com/go/+/refs/tags/go${VERSION_NEW}"
+
+generate_update_changelog 'Go' "${VERSION_NEW}" "${URL}" 'golang'
+
 generate_patches dev-lang go Go
 
 apply_patches

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -36,6 +36,10 @@ done
 
 popd >/dev/null || exit
 
+URL="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tag/?h=v${VERSION_NEW}"
+
+generate_update_changelog 'Linux' "${VERSION_NEW}" "${URL}" 'linux'
+
 generate_patches sys-kernel coreos-sources Kernel
 
 apply_patches

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -49,6 +49,10 @@ sed -i "s/docker-runc-${VERSION_OLD}/docker-runc-${VERSION_NEW}/g" ${torcxEbuild
 
 popd >/dev/null || exit
 
+URL="https://github.com/opencontainers/runc/releases/tag/v${VERSION_NEW}"
+
+generate_update_changelog 'runc' "${VERSION_NEW}" "${URL}" 'runc'
+
 generate_patches app-emulation docker-runc Runc
 
 apply_patches

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -32,6 +32,10 @@ git mv "${EBUILD_FILENAME}" "dev-lang/rust/rust-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 
+URL="https://github.com/rust-lang/rust/releases/tag/${VERSION_NEW}"
+
+generate_update_changelog 'Rust' "${VERSION_NEW}" "${URL}" 'rust'
+
 generate_patches dev-lang rust dev-lang/rust profiles
 
 apply_patches

--- a/.github/workflows/vmware-apply-patch.sh
+++ b/.github/workflows/vmware-apply-patch.sh
@@ -31,23 +31,13 @@ git mv "${EBUILD_FILENAME_OVT}" "app-emulation/open-vm-tools/open-vm-tools-${VER
 # We need to also replace the old build number with the new build number in the ebuild.
 sed -i -e "s/^\(MY_P=.*-\)[0-9]*\"$/\1${BUILD_NUMBER}\"/" app-emulation/open-vm-tools/open-vm-tools-${VERSION_NEW}.ebuild
 
-popd >/dev/null || exit
-
-generate_patches app-emulation open-vm-tools open-vm-tools
-
-apply_patches
-
-
-# Update coreos-base/oem-vmware
-
-pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit
-
+# Also update coreos-base/oem-vmware
 EBUILD_FILENAME_OEM=$(get_ebuild_filename "coreos-base" "oem-vmware" "${VERSION_OLD}")
 git mv "${EBUILD_FILENAME_OEM}" "coreos-base/oem-vmware/oem-vmware-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 
-generate_patches coreos-base oem-vmware oem-vmware
+generate_patches app-emulation open-vm-tools open-vm-tools coreos-base/oem-vmware
 
 apply_patches
 

--- a/.github/workflows/vmware-apply-patch.sh
+++ b/.github/workflows/vmware-apply-patch.sh
@@ -37,6 +37,10 @@ git mv "${EBUILD_FILENAME_OEM}" "coreos-base/oem-vmware/oem-vmware-${VERSION_NEW
 
 popd >/dev/null || exit
 
+URL="https://github.com/vmware/open-vm-tools/releases/tag/stable-${VERSION_NEW}"
+
+generate_update_changelog 'open-vm-tools' "${VERSION_NEW}" "${URL}" 'open-vm-tools'
+
 generate_patches app-emulation open-vm-tools open-vm-tools coreos-base/oem-vmware
 
 apply_patches


### PR DESCRIPTION
It's a bit dumb, as it only generates the update changelogs. If the update addresses some CVE, it needs to be added manually. The only smarts it has is that it will handle missing `changelog` directory gracefully.

This also adds some fixes:

- for docker job - add changes made in other packages too (torcx docker, docker-runc and docker-cli)
- for vmware job - update both open-vm-tools and coreos-base/oem-vmware under a single commit