### PR TITLE
coreos-base/coreos-init: bump init repo to add flatcar-update tool

### DIFF
--- a/changelog/changes/2021-12-02-flatcar-update.md
+++ b/changelog/changes/2021-12-02-flatcar-update.md
@@ -1,0 +1,1 @@
+- Added a new flatcar-update tool to the image to ease manual updates, rollbacks, channel/release jumping, and airgapped updates ([PR#53](https://github.com/flatcar-linux/init/pull/53))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="a3aec0e8daa5ce7b6221356710c3463eff238c4b" # flatcar-master
+	CROS_WORKON_COMMIT="58360ed0da957c2cd0ae9eeab645735d814f565c" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/init/pull/53 to add the
"flatcar-update" tool to the image, easing manual updates, rollbacks,
channel/release jumping, and airgapped updates.

## How to use

Pick for flatcar-3066 (the other ones would need a branched init repo reference)

## Testing done

See linked PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
