### PR TITLE
coreos-base/update_engine: Create reboot flag file for kured

### DIFF
--- a/changelog/changes/2021-12-06-update-engine-kured.md
+++ b/changelog/changes/2021-12-06-update-engine-kured.md
@@ -1,0 +1,1 @@
+- Update-engine now creates the `/run/reboot-required` flag file for [kured](https://github.com/weaveworks/kured) ([PR#15](https://github.com/flatcar-linux/update_engine/pull/15))

--- a/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/coreos-base/update_engine/update_engine-9999.ebuild
@@ -8,7 +8,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="858f3a502d88f031aca88d590bfb2b922f0dfc8a" # flatcar-master
+	CROS_WORKON_COMMIT="04a76854b82f448f814ed46958c4d53ff27eefd7" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/update_engine/pull/15 to create the
Ubuntu-compatible /run/reboot-required flag file for kured.

## How to use/Testing done

see https://github.com/flatcar-linux/update_engine/pull/15


- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
