### PR TITLE
.github/wf: add mirror-calico action

### DIFF
--- a/.github/workflows/mirror-calico.sh
+++ b/.github/workflows/mirror-calico.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script will mirror the list of Calico images
+# from Docker Hub to GHCR.
+
+# tag will hold the version of calico images we
+# previously fetched
+tag=$1
+
+# list of images to mirror from Docker Hub
+images=(
+  calico/typha
+  calico/pod2daemon-flexvol
+  calico/cni
+  calico/node
+  calico/kube-controllers
+)
+
+# we iterate over the images we want to mirror
+for image in "${images[@]}"; do
+  ./mirror-to-ghcr.sh $image $tag
+done

--- a/.github/workflows/mirror-calico.yml
+++ b/.github/workflows/mirror-calico.yml
@@ -1,0 +1,26 @@
+name: Sync GHCR Calico images with Docker Hub
+on:
+  schedule:
+    # run every 12h
+    - cron:  '0 */12 * * *'
+  workflow_dispatch:
+
+jobs:
+  get-docker-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry (ghcr)
+        run: echo ${{ secrets.GHCR_PASSWORD }} | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
+      - name: Fetch latest Calico release
+        id: fetch-latest-release
+        run: |
+          set -ex
+
+          git clone https://github.com/projectcalico/calico calico
+          # get latest version
+          version=$(git -C "$_" tag | sort -V | tail -1)
+
+          pushd .github/workflows/
+          ./mirror-calico.sh $version
+          popd

--- a/.github/workflows/mirror-to-ghcr.sh
+++ b/.github/workflows/mirror-to-ghcr.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This generic script aims to mirror an image from Docker hub to another registry.
+# Authentication to the registry must be done before.
+
+image=$1
+imagetag=$2
+registry=${3:-kinvolk}
+
+# we want both arch for running tests
+platforms=( amd64 arm64 )
+
+# tags will hold the mirrored images
+tags=()
+
+for platform in "${platforms[@]}"; do
+  # we first fetch the image from Docker Hub
+  var=$(docker pull $image:$imagetag --platform=linux/$platform -q)
+  # we prepare the image to be pushed into another registry
+  tag=ghcr.io/$registry/$image:$imagetag-$platform
+  # we tag the image to create the mirrored image
+  docker tag $var $tag
+  docker push $tag
+  tags+=( $tag )
+done
+
+docker manifest create ghcr.io/$registry/$image:$imagetag "${tags[@]}"
+# some images have bad arch specs in the individual image manifests :(
+docker manifest annotate ghcr.io/$registry/$image:$imagetag ghcr.io/$registry/$image:$imagetag-arm64 --arch arm64
+docker manifest push --purge ghcr.io/$registry/$image:$imagetag


### PR DESCRIPTION
this action will sync our ghcr calico images with upstream docker
images.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

`kubeadm.*.calico` tests are using Calico images from GHCR in order to circumvent Docker hub pulling rate limit, the issue is that we can't really pin the image tag used by Calico tests (see: https://github.com/projectcalico/calico/issues/5121) so each time Calico is releasing, CI is failing while images are not updated into GHCR.
It should be a temporary thing :tm: while https://github.com/projectcalico/calico/issues/5121 is being handled :) 

Script is based on internal custom scripts we were currently using. 


Tested on my fork: https://github.com/tormath1/coreos-overlay/actions/runs/1548773225

