### PR TITLE
changelog: add missing CVE for golang.org/x/text in ignition

### DIFF
--- a/changelog/security/2021-11-30-golang-text-ignition.md
+++ b/changelog/security/2021-11-30-golang-text-ignition.md
@@ -1,1 +1,2 @@
 - [CVE-2020-14040](https://nvd.nist.gov/vuln/detail/CVE-2020-14040)
+- [CVE-2021-38561](https://nvd.nist.gov/vuln/detail/CVE-2021-38561)


### PR DESCRIPTION
We missed changelog for [CVE-2021-38561](https://nvd.nist.gov/vuln/detail/CVE-2021-38561) when updating `golang.org/x/text` to 0.3.7 in ignition.
