### PR TITLE
coreos-base/coreos-init: prevent networkd interference with cbr0 iface

### DIFF
--- a/changelog/bugfixes/2021-12-09-set-kubenet-cbr0-unmanaged.md
+++ b/changelog/bugfixes/2021-12-09-set-kubenet-cbr0-unmanaged.md
@@ -1,0 +1,1 @@
+- Excluded the Kubenet cbr0 interface from networkd's DHCP config and set it to Unmanaged to prevent interference and ensure that it is not part of the network online check ([PR#55](https://github.com/flatcar-linux/init/pull/55))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="80b3b3cd021b4120cd9218b33b1f92936abe00bb" # flatcar-master
+	CROS_WORKON_COMMIT="bf688adbf34cc16b613608a2ee3c4a7f30a54395" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/init/pull/55 to set the
cbr0 interface to be excluded from networkd (unmanaged) because it is
set up manually by kubenet and not through DHCP.

## How to use


## Testing done

See PR, will also start a test build just to be sure

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
