### PR TITLE
coreos-base/coreos-init: exclude bridge ifaces from the DHCP config

### DIFF
--- a/changelog/changes/2021-12-16-exclude-bridge-and-tunnels-from-DHCP.md
+++ b/changelog/changes/2021-12-16-exclude-bridge-and-tunnels-from-DHCP.md
@@ -1,0 +1,1 @@
+- Excluded special network interface devices like bridge, tunnel, vxlan, and veth devices from the default DHCP configuration to prevent networkd interference ([PR#56](https://github.com/flatcar-linux/init/pull/56))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="5167ee585e57a66fdba652044267dcb27b765578" # flatcar-master
+	CROS_WORKON_COMMIT="3a95bb3a7bc6866ab456c8b7705400ac18ce5b27" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in [flatcar-linux/init#56](https://github.com/flatcar-linux/init/pull/56)
to find a generic way of preventing conflicts with CNI interfaces that
shouldn't use DHCP and were matched by name to be set Unmanaged.


## How to use


## Testing done

started CI run, will maybe extend it to more platforms

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
