### PR TITLE
profiles: adjust profiles for vim 8.2.3582 for flatcar-3033,3066

### DIFF
--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -4,3 +4,6 @@ sys-firmware/intel-microcode vanilla
 
 # Enable gssapi only for amd64, to avoid build errors in arm64.
 net-dns/bind-tools           gssapi
+
+# Disable crypt to avoid installing libsodlium in amd64.
+app-editors/vim		-crypt

--- a/profiles/coreos/arm64/generic/package.use
+++ b/profiles/coreos/arm64/generic/package.use
@@ -1,0 +1,2 @@
+# Disable crypt to avoid installing libsodlium in arm64.
+app-editors/vim		-crypt

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -4,11 +4,6 @@
 
 =app-arch/zstd-1.4.9 ~amd64 ~arm64
 
-# To address security issues like CVE-2021-3770, we need to acccept
-# keywords for vim 8.2.3428.
-=app-editors/vim-8.2.3428 ~amd64 ~arm64
-=app-editors/vim-core-8.2.3428 ~amd64 ~arm64
-
 =coreos-devel/fero-client-0.1.1 **
 
 # Accept unstable host Rust compilers


### PR DESCRIPTION
Delete unnecessary keywords after updating vim to 8.2.3582.
Disable the USE flag `crypt` for vim, not to pull in unnecessary dependency libsodium.

This issue was already addressed via https://github.com/flatcar-linux/coreos-overlay/pull/1455, but only for main.
That's why we need to fix it also in maintenance branches.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/260 .

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4355/cldsv

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (please see https://github.com/flatcar-linux/portage-stable/pull/260)
