### PR TITLE
sys-apps/policycoreutils: update correct SELinux store

### DIFF
--- a/changelog/bugfixes/2021-12-16-policycoreutils-fix-semodule-postinst.md
+++ b/changelog/bugfixes/2021-12-16-policycoreutils-fix-semodule-postinst.md
@@ -1,0 +1,10 @@
+The policycoreutils ebuild calls semodule in postinst to update SELinux stores.
+It does not, however, tells semodule the correct ROOT to use, so builds that go into /build/[arch]-usr end up updating the SDK's store.
+This patch resolves the following error message:
+```
+$ emerge-amd64-usr policycoreutils
+[...]
+libsemanage.semanage_commit_sandbox: Error while renaming /var/lib/selinux/targeted/active to /var/lib/selinux/targeted/previous. (Invalid cross-device link)
+```
+The error is observed when using the SDK Container to build an OS image.
+The `semanage` run in policycoreutilsi' `postinst`  now also updates the correct store, which it previously did not.

--- a/sys-apps/policycoreutils/policycoreutils-3.1-r3.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-3.1-r3.ebuild
@@ -219,7 +219,7 @@ pkg_postinst() {
 	for POLICY_TYPE in ${POLICY_TYPES} ; do
 		# There have been some changes to the policy store, rebuilding now.
 		# https://marc.info/?l=selinux&m=143757277819717&w=2
-		einfo "Rebuilding store ${POLICY_TYPE} (without re-loading)."
-		semodule -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
+		einfo "Rebuilding store ${POLICY_TYPE} in '${ROOT}' (without re-loading)."
+		semodule -S "${ROOT}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
 	done
 }

--- a/sys-apps/policycoreutils/policycoreutils-3.1-r3.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-3.1-r3.ebuild
@@ -219,7 +219,7 @@ pkg_postinst() {
 	for POLICY_TYPE in ${POLICY_TYPES} ; do
 		# There have been some changes to the policy store, rebuilding now.
 		# https://marc.info/?l=selinux&m=143757277819717&w=2
-		einfo "Rebuilding store ${POLICY_TYPE} in '${ROOT}' (without re-loading)."
-		semodule -S "${ROOT}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
+		einfo "Rebuilding store ${POLICY_TYPE} in '${ROOT:-/}' (without re-loading)."
+		semodule -S "${ROOT:-/}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
 	done
 }


### PR DESCRIPTION
The policycoreutils ebuild calls `semodule` in postinst to update SELinux stores.
It does not, however, tells `semodule` the correct ROOT to use, so builds that go into `/build/[arch]-usr` end up updating the SDK's store.
Fixes 
   libsemanage.semanage_commit_sandbox: Error while renaming /var/lib/selinux/targeted/active to /var/lib/selinux/targeted/previous. (Invalid cross-device link)
observed when using the SDK Container to build the OS image.
It now also updates the correct store, which it previously did not.

We should consider cherry-picking this patch to flatcar-3033, flatcar-3066, and flatcar-3087.

<hr>

CI (running): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4397/cldsv/