### PR TITLE
coreos-base/coreos-init: ensure /run/xtables.lock exists

### DIFF
--- a/changelog/bugfixes/2021-12-16-ensure-xtables-lock-exists.md
+++ b/changelog/bugfixes/2021-12-16-ensure-xtables-lock-exists.md
@@ -1,0 +1,1 @@
+- Ensured that the `/run/xtables.lock` coordination file exists for modifications of the xtables backend from containers (must be bind-mounted) or the `iptables-legacy` binaries on the host ([PR#57](https://github.com/flatcar-linux/init/pull/57))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="bf688adbf34cc16b613608a2ee3c4a7f30a54395" # flatcar-master
+	CROS_WORKON_COMMIT="5167ee585e57a66fdba652044267dcb27b765578" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/init/pull/57
to make sure the /run/xtables.lock file exists for coordination of
xtables modifications.


## How to use

Backport to Alpha, Beta, maybe also Stable but it needs to have its own init repo branch

## Testing done

see linked PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
