### PR TITLE
profiles/coreos/base: backport `iproute2` ELF support

### DIFF
--- a/changelog/changes/2021-12-21-iproute-with-elf.md
+++ b/changelog/changes/2021-12-21-iproute-with-elf.md
@@ -1,0 +1,1 @@
+- Backported `elf` support for `iproute2` [flatcar-linux/coreos-overlay#1256](https://github.com/flatcar-linux/coreos-overlay/pull/1526)

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -139,3 +139,6 @@ sys-auth/polkit -introspection
 net-misc/openssh -bindist
 
 dev-libs/openssl fips
+
+# enables ELF support to e.g. allow tc to handle BPF filters.
+sys-apps/iproute2 elf


### PR DESCRIPTION
enables ELF support to e.g. allow tc to handle BPF filters.

It has been dropped in this commit: https://github.com/flatcar-linux/portage-stable/commit/406576c5e554e10950c82fa7f3692d62743958b2

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Close: https://github.com/flatcar-linux/Flatcar/issues/584

CI (running): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4446/cldsv/

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)


NOTE: This can be safely cherry-picked to maintenance branches
