### PR TITLE
.github: Use different kernel changelog file name per version

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -85,7 +85,7 @@ function generate_update_changelog() {
   local URL="${3}"
   local UPDATE_NAME="${4}"
   shift 4
-  local file="changelog/updates/$(date '+%Y-%m-%d')-${UPDATE_NAME}-update.md"
+  local file="changelog/updates/$(date '+%Y-%m-%d')-${UPDATE_NAME}-${VERSION}-update.md"
   local -a old_links
 
   pushd "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" >/dev/null || exit


### PR DESCRIPTION
All runs of the GitHub Action to update the kernel used the same
changelog name, which is a bit confusing when comparing the releases.
Append the version to the filename to avoid using the same name for the
maintenance updates of a channel releases and for the introduction of a
kernel update in main.

## How to use

## Testing done

None
