### PR TITLE
changelog: rewrite entry for PR 1502

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -9,9 +9,17 @@ into the repository.  The changes are essentially divided into 4 categories:
 
 Based on the category the PR falls into create a new file in the respective
 directory with the filename format `YYYY-MM-DD-<few-words-about-the-change>.md`
-(can be generated via: `$(date '+%Y-%m-%d')-<few-words-about-the-change>.md`)
+(can be generated via: `$(date '+%Y-%m-%d')-<few-words-about-the-change>.md`).
+The file should contain a markdown bullet point entry (`- TEXT...`).
 
-The contents of the file should describe the changes in an elaborative manner
+Example for the bugfix section:
+
+```
+- The Torcx profile `docker-1.12-no` got fixed to reference the current Docker version instead of 19.03 which wasn't found on the image, causing Torcx to fail to provide Docker [PR#1456](https://github.com/flatcar-linux/coreos-overlay/pull/1456)
+```
+
+The contents of the file should describe the changes in a concise manner,
+and only contain information relevant for the end users.
 (use the past tense for the change/bugfix description to avoid confusion with
 the imperative voice for actions the user should do as a result). Security
 fixes of upstream packages and package updates can be kept short in most cases

--- a/changelog/bugfixes/2021-12-16-policycoreutils-fix-semodule-postinst.md
+++ b/changelog/bugfixes/2021-12-16-policycoreutils-fix-semodule-postinst.md
@@ -1,10 +1,1 @@
-The policycoreutils ebuild calls semodule in postinst to update SELinux stores.
-It does not, however, tells semodule the correct ROOT to use, so builds that go into /build/[arch]-usr end up updating the SDK's store.
-This patch resolves the following error message:
-```
-$ emerge-amd64-usr policycoreutils
-[...]
-libsemanage.semanage_commit_sandbox: Error while renaming /var/lib/selinux/targeted/active to /var/lib/selinux/targeted/previous. (Invalid cross-device link)
-```
-The error is observed when using the SDK Container to build an OS image.
-The `semanage` run in policycoreutilsi' `postinst`  now also updates the correct store, which it previously did not.
+- SDK: Fixed build error popping up in the new SDK Container because `policycoreutils` used the wrong ROOT to update the SELinux store ([PR#1502](https://github.com/flatcar-linux/coreos-overlay/pull/1502))


### PR DESCRIPTION
The used changelog entry format in
https://github.com/flatcar-linux/coreos-overlay/pull/1502 is not really
useful for the release notes. This paragraph is good for the PR
description or a commit message, but here should be a bullet point for
the release notes.
Replace the paragraph by a release notes bullet point.

Also contains the same README update as
https://github.com/flatcar-linux/portage-stable/pull/266
and 
https://github.com/flatcar-linux/scripts/pull/195