### PR TITLE
Drop obsolete stuff after updating profiles

### DIFF
--- a/profiles/coreos/base/package.mask
+++ b/profiles/coreos/base/package.mask
@@ -14,3 +14,10 @@
 # Since version 2, it tries to write liblto symlinks with absolute paths that
 # don't work when building for the board root directories.
 >=sys-devel/gcc-config-2
+
+# Overwrite portage-stable mask. We are delaying the transition to
+# libxcrypt, because we need to figure out how to solve the dep loop
+# that results from the migration (python -> virtual/libcrypt ->
+# libxcrypt -> glibc -> python), and also we need to update gcc to
+# version 10 or later.
+>=virtual/libcrypt-2

--- a/profiles/coreos/base/package.unmask
+++ b/profiles/coreos/base/package.unmask
@@ -5,3 +5,10 @@
 # gentoo. We still need it, since sys-libs/libsemanage still requires
 # it. When we update selinux, this can be dropped.
 =dev-libs/ustr-1.0.4-r8
+
+# Overwrite portage-stable mask. We are delaying the transition to
+# libxcrypt, because we need to figure out how to solve the dep loop
+# that results from the migration (python -> virtual/libcrypt ->
+# libxcrypt -> glibc -> python), and also we need to update gcc to
+# version 10 or later.
+=virtual/libcrypt-1-r1

--- a/profiles/coreos/base/package.use.mask
+++ b/profiles/coreos/base/package.use.mask
@@ -19,3 +19,10 @@ sys-libs/ncurses cxx
 # To fix that, exclude the unicode USE flag from packages.use.force list,
 # which is defined in portage-stable.
 app-editors/nano unicode
+
+# Overwrite portage-stable mask. We are delaying the transition to
+# libxcrypt, because we need to figure out how to solve the dep loop
+# that results from the migration (python -> virtual/libcrypt ->
+# libxcrypt -> glibc -> python), and also we need to update gcc to
+# version 10 or later.
+sys-libs/glibc -crypt

--- a/profiles/features/systemd/package.accept_keywords
+++ b/profiles/features/systemd/package.accept_keywords
@@ -1,3 +1,2 @@
 # Various dependencies that also need to be up-to-date
-sys-apps/hwids                  ~amd64 ~x86
 sys-apps/kmod                   ~amd64 ~x86

--- a/sys-apps/portage/portage-3.0.28-r1.ebuild
+++ b/sys-apps/portage/portage-3.0.28-r1.ebuild
@@ -61,7 +61,6 @@ RDEPEND="
 	)
 	elibc_glibc? ( >=sys-apps/sandbox-2.2 )
 	elibc_musl? ( >=sys-apps/sandbox-2.2 )
-	elibc_uclibc? ( >=sys-apps/sandbox-2.2 )
 	kernel_linux? ( sys-apps/util-linux )
 	>=app-misc/pax-utils-0.1.17
 	selinux? ( >=sys-libs/libselinux-2.0.94[python,${PYTHON_USEDEP}] )

--- a/sys-libs/ldb/ldb-2.3.0-r2.ebuild
+++ b/sys-libs/ldb/ldb-2.3.0-r2.ebuild
@@ -22,7 +22,6 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	!elibc_FreeBSD? ( dev-libs/libbsd[${MULTILIB_USEDEP}] )
 	dev-libs/popt[${MULTILIB_USEDEP}]
 	>=dev-util/cmocka-1.1.3[${MULTILIB_USEDEP}]
 	>=sys-libs/talloc-2.3.1[${MULTILIB_USEDEP}]

--- a/sys-libs/timezone-data/timezone-data-2019b-r2.ebuild
+++ b/sys-libs/timezone-data/timezone-data-2019b-r2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://www.iana.org/time-zones/repository/releases/tzdata${data_ver}.t
 LICENSE="BSD public-domain"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 ~riscv s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
-IUSE="nls leaps-timezone elibc_FreeBSD"
+IUSE="nls leaps-timezone"
 
 DEPEND="nls? ( virtual/libintl )"
 RDEPEND="${DEPEND}
@@ -38,7 +38,7 @@ src_configure() {
 
 	append-lfs-flags #471102
 
-	if use elibc_FreeBSD || use elibc_Darwin ; then
+	if use elibc_Darwin ; then
 		append-cppflags -DSTD_INSPIRED #138251
 	fi
 

--- a/sys-libs/timezone-data/timezone-data-2019c.ebuild
+++ b/sys-libs/timezone-data/timezone-data-2019c.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://www.iana.org/time-zones/repository/releases/tzdata${data_ver}.t
 LICENSE="BSD public-domain"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 ~riscv s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
-IUSE="nls leaps-timezone elibc_FreeBSD"
+IUSE="nls leaps-timezone"
 
 DEPEND="nls? ( virtual/libintl )"
 RDEPEND="${DEPEND}
@@ -38,7 +38,7 @@ src_configure() {
 
 	append-lfs-flags #471102
 
-	if use elibc_FreeBSD || use elibc_Darwin ; then
+	if use elibc_Darwin ; then
 		append-cppflags -DSTD_INSPIRED #138251
 	fi
 


### PR DESCRIPTION
A bunch of things has changed recently:

- Crypt functionality in glibc was deprecated in favor of using libxcrypt. For now I'm reverting the deprecation, so we still keep using crypt from glibc, as the migration has some blockers for us (see #1543).
- uclibc was removed, so we need to drop all mentions of `elibc_uclibc`.
- Same with mintlib, so we need to drop all mentions of `elibc_mintlib`.
- `sys-apps/hwids` was deprecated in favor of `sys-apps/hwdata`, so we migrate to it
  - systemd needed some small sync with gentoo in this regard

Needs to be merged together with https://github.com/flatcar-linux/portage-stable/pull/268.

CI: http://localhost:9091/job/os/job/manifest/4566/cldsv/