### PR TITLE
profiles/coreos/arm64: build target packages with '-moutline-atomics'

### DIFF
--- a/profiles/coreos/arm64/generic/make.defaults
+++ b/profiles/coreos/arm64/generic/make.defaults
@@ -1,2 +1,2 @@
-CFLAGS="-O2 -pipe -mtune=generic -g"
+CFLAGS="-O2 -pipe -mtune=generic -moutline-atomics -g"
 CXXFLAGS="${CFLAGS}"


### PR DESCRIPTION
# profiles/coreos/arm64: build target packages with '-moutline-atomics'

This should benefit more modern ARM systems (Altra/Graviton2) while keeping compatibility with older platforms (RPi4).
See commit message for a longer description.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
