### PR TITLE
Changes for net-misc/iputils update

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -12,7 +12,7 @@ dev-util/perf		tui -doc
 dev-vcs/git		webdav curl bash-completion
 # We don't want any driver/hw rendering on the host
 net-misc/curl		kerberos threads telnet
-net-misc/iputils	arping tracepath traceroute
+net-misc/iputils	arping tracepath traceroute6
 sys-devel/gettext	-git
 app-emulation/qemu	aio caps curl -doc ncurses png python threads uuid vhost-net virtfs vnc -xkb -slirp -jpeg qemu_softmmu_targets_x86_64 qemu_softmmu_targets_aarch64
 

--- a/sec-policy/selinux-base-policy/files/ping.patch
+++ b/sec-policy/selinux-base-policy/files/ping.patch
@@ -1,0 +1,19 @@
+diff -u -r refpolicy/policy/modules/admin/netutils.te refpolicy/policy/modules/admin/netutils.te
+--- refpolicy/policy/modules/admin/netutils.te	2022-01-12 14:28:26.850809330 -0000
++++ refpolicy/policy/modules/admin/netutils.te	2022-01-12 14:29:50.323880882 -0000
+@@ -117,6 +117,7 @@
+ corenet_raw_sendrecv_generic_node(ping_t)
+ corenet_tcp_sendrecv_generic_node(ping_t)
+ corenet_raw_bind_generic_node(ping_t)
++corenet_icmp_bind_generic_node(ping_t)
+ 
+ dev_read_urand(ping_t)
+ 
+@@ -189,6 +190,7 @@
+ corenet_tcp_connect_all_ports(traceroute_t)
+ corenet_sendrecv_all_client_packets(traceroute_t)
+ corenet_sendrecv_traceroute_server_packets(traceroute_t)
++corenet_icmp_bind_generic_node(traceroute_t)
+ 
+ dev_read_rand(traceroute_t)
+ dev_read_urand(traceroute_t)

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20200818-r2.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20200818-r2.ebuild
@@ -43,6 +43,8 @@ PATCHES=(
 	# to fail if SELinux is enforced in early boot.
 	# It can be removed once we drop torcx support.
 	"${FILESDIR}/unlabeled.patch"
+	# This is to allow pings from some IP address.
+	"${FILESDIR}/ping.patch"
 )
 
 # Code entirely copied from selinux-eclass (cannot inherit due to dependency on

--- a/sec-policy/selinux-base/files/icmp-bind.patch
+++ b/sec-policy/selinux-base/files/icmp-bind.patch
@@ -1,0 +1,40 @@
+diff -u -r refpolicy/policy/modules/kernel/corenetwork.if.in refpolicy2/policy/modules/kernel/corenetwork.if.in
+--- refpolicy/policy/modules/kernel/corenetwork.if.in	2022-01-12 16:59:47.572670384 -0000
++++ refpolicy2/policy/modules/kernel/corenetwork.if.in	2022-01-12 17:01:54.974858982 -0000
+@@ -879,6 +879,24 @@
+ 
+ ########################################
+ ## <summary>
++##	Bind ICMP sockets to generic nodes.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`corenet_icmp_bind_generic_node',`
++	gen_require(`
++		type node_t;
++	')
++
++	allow $1 node_t:icmp_socket node_bind;
++')
++
++########################################
++## <summary>
+ ##	Bind TCP sockets to generic nodes.
+ ## </summary>
+ ## <desc>
+diff -u -r refpolicy/policy/modules/kernel/corenetwork.te.in refpolicy2/policy/modules/kernel/corenetwork.te.in
+--- refpolicy/policy/modules/kernel/corenetwork.te.in	2022-01-12 16:59:47.573670362 -0000
++++ refpolicy2/policy/modules/kernel/corenetwork.te.in	2022-01-12 17:03:12.754142616 -0000
+@@ -373,7 +373,7 @@
+ 
+ # Bind to any network address.
+ allow corenet_unconfined_type port_type:{ tcp_socket udp_socket rawip_socket sctp_socket } name_bind;
+-allow corenet_unconfined_type node_type:{ tcp_socket udp_socket rawip_socket sctp_socket } node_bind;
++allow corenet_unconfined_type node_type:{ icmp_socket tcp_socket udp_socket rawip_socket sctp_socket } node_bind;
+ 
+ # Infiniband
+ corenet_ib_access_all_pkeys(corenet_unconfined_type)

--- a/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
+++ b/sec-policy/selinux-base/selinux-base-2.20200818-r2.ebuild
@@ -43,6 +43,7 @@ BDEPEND="sys-devel/m4
 PATCHES=(
 	"${FILESDIR}"/0001-policy-modules-kernel-all-more-actions-for-kernel.patch
 	"${FILESDIR}"/0001-policy-ms-MCS-restricts-relabelfrom.patch
+	"${FILESDIR}"/icmp-bind.patch
 )
 
 S=${WORKDIR}/


### PR DESCRIPTION
This adds a patch to selinux policy to allow `ping -I` and updates the use flags.

Needs to be merged together with https://github.com/flatcar-linux/portage-stable/pull/270.

CI: http://localhost:9091/job/os/job/manifest/4576/cldsv/