### PR TITLE
.github: find latest calico tag when mirroring

### DIFF
--- a/.github/workflows/mirror-calico.yml
+++ b/.github/workflows/mirror-calico.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  get-docker-release:
+  mirror-calico:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,10 +17,19 @@ jobs:
         run: |
           set -ex
 
-          git clone https://github.com/projectcalico/calico calico
-          # get latest version
-          version=$(git -C "$_" tag | sort -V | tail -1)
+          tigera_image=$(curl -sSL  https://docs.projectcalico.org/manifests/tigera-operator.yaml \
+            | awk '/image:/ && NF == 2 { print $2 }')
+          tigera_version=${tigera_image##*:}
+
+          versions=$(curl -sSL "https://raw.githubusercontent.com/tigera/operator/${tigera_version}/config/calico_versions.yml" \
+            | awk '/version:/ { print $2 }' \
+            | sort \
+            | uniq)
+
+          echo "Found versions: $versions"
 
           pushd .github/workflows/
-          ./mirror-calico.sh $version
+          for version in $versions; do
+            ./mirror-calico.sh $version
+          done
           popd


### PR DESCRIPTION
# .github: find latest calico tag when mirroring

Workflow is currently failing because it finds the wrong tag, this commit fixes that.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

```
$ git clone https://github.com/projectcalico/calico calico
$ git -C calico tag --sort=-authordate | head -1
v3.21.3
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
