### PR TITLE
sys-apps/policycoreutils: fix policy root path

### DIFF
--- a/changelog/bugfixes/2022-01-13-policycoreutils-fix-root-path.md
+++ b/changelog/bugfixes/2022-01-13-policycoreutils-fix-root-path.md
@@ -1,0 +1,1 @@
+- Fixed leak of SELinux policy store to the root filesystem top directory due to wrong store path in `policycoreutils` instead of `/var/lib/selinux` ([flatcar-linux/Flatcar#596](https://github.com/flatcar-linux/Flatcar/issues/596))

--- a/sys-apps/policycoreutils/policycoreutils-3.1-r3.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-3.1-r3.ebuild
@@ -220,6 +220,6 @@ pkg_postinst() {
 		# There have been some changes to the policy store, rebuilding now.
 		# https://marc.info/?l=selinux&m=143757277819717&w=2
 		einfo "Rebuilding store ${POLICY_TYPE} in '${ROOT:-/}' (without re-loading)."
-		semodule -S "${ROOT:-/}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
+		semodule -p "${ROOT:-/}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
 	done
 }


### PR DESCRIPTION
root needs to be specified with -p instead of -S.
The policy dir (-S) defaults to (-p) + /var/lib/selinux/ + (-s).

Picked from upstream: https://github.com/gentoo/gentoo/commit/54a8322d1885f7f1bfe2718fb731d6e195f86466

Closes: https://github.com/flatcar-linux/Flatcar/issues/596
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

# How to use

Pick for `flatcar-3115` when merging

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)

CI OK for amd64 - but not for ARM64, error with `iputils` but not related: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4585/cldsv/