### PR TITLE
coreos-base/coreos-init/coreos-init: pull in latest changes

### DIFF
--- a/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
+++ b/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
@@ -1,0 +1,1 @@
+- network: Accept ICMPv6 Router Advertisements to fix IPv6 address assignment in the default DHCP setting ([PR#51](https://github.com/flatcar-linux/init/pull/51))

--- a/changelog/bugfixes/2022-01-26-flatcar-update-user-env-var.md
+++ b/changelog/bugfixes/2022-01-26-flatcar-update-user-env-var.md
@@ -1,0 +1,1 @@
+- flatcar-update: Stopped checking for the `USER` environment variable which may not be set in all environments, causing the script to fail unless a workaround was used like prepending an additional `sudo` invocation ([PR#58](https://github.com/flatcar-linux/init/pull/58))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="3a95bb3a7bc6866ab456c8b7705400ac18ce5b27" # flatcar-master
+	CROS_WORKON_COMMIT="d9738cf5281d5bd9849d01e1f5f8f9391d82d13d" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/init/pull/58
(bin/flatcar-update: don't assume $USER is set up, only use $EUID)
and
https://github.com/flatcar-linux/init/pull/51
network: Enable the RAs to fix IPv6 address assignment

## How to use


## Testing done

None for the RA change, this just got dragged in because there was no update for it separately - it's assumed to fix the IPv6 related bug reports and we need some more PRs to update the other components which have the change merged already

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
