### PR TITLE
coreos-cloudinit and bootengine: accept IPv6 RA for default net configs

### DIFF
--- a/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
+++ b/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
@@ -1,1 +1,1 @@
-- network: Accept ICMPv6 Router Advertisements to fix IPv6 address assignment in the default DHCP setting ([PR#51](https://github.com/flatcar-linux/init/pull/51))
+- network: Accept ICMPv6 Router Advertisements to fix IPv6 address assignment in the default DHCP setting ([PR#51](https://github.com/flatcar-linux/init/pull/51), [PR#12](https://github.com/flatcar-linux/coreos-cloudinit/pull/12), [PR#30](https://github.com/flatcar-linux/bootengine/pull/30))

--- a/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -12,7 +12,7 @@ inherit cros-workon systemd toolchain-funcs udev coreos-go
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="cfcc44197d11f44441e5aa2c9db34bcd0bf16015" # flatcar-master
+	CROS_WORKON_COMMIT="4de1033b7a0600c84ea86f8fac8b580116f4f8f1" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="18384ea43e3d63f020de6108e0605d6d01ffdf8d" # flatcar-master
+	CROS_WORKON_COMMIT="bced9373ee9f11028b3c9d704fbca3d2e059a4ef" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/coreos-cloudinit/pull/12
and
https://github.com/flatcar-linux/bootengine/pull/30
(https://github.com/flatcar-linux/init/pull/51 is already in)
to also accept Router Advertisements in our default DHCP network
configurations.


## How to use

## Testing done

None

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
