### PR TITLE
sys-auth/polkit: backport patch for CVE-4034

### DIFF
--- a/changelog/security/2022-01-27-polkit.md
+++ b/changelog/security/2022-01-27-polkit.md
@@ -1,0 +1,1 @@
+- polkit ([CVE-2021-4034](https://nvd.nist.gov/vuln/detail/CVE-2021-4034))

--- a/sys-auth/polkit/files/polkit-0.120-CVE-2021-4034.patch
+++ b/sys-auth/polkit/files/polkit-0.120-CVE-2021-4034.patch
@@ -1,0 +1,72 @@
+https://www.qualys.com/2022/01/25/cve-2021-4034/pwnkit.txt
+https://bugs.gentoo.org/832057
+https://gitlab.freedesktop.org/polkit/polkit/-/commit/a2bf5c9c83b6ae46cbd5c779d3055bff81ded683.patch
+
+From a2bf5c9c83b6ae46cbd5c779d3055bff81ded683 Mon Sep 17 00:00:00 2001
+From: Jan Rybar <jrybar@redhat.com>
+Date: Tue, 25 Jan 2022 17:21:46 +0000
+Subject: [PATCH] pkexec: local privilege escalation (CVE-2021-4034)
+
+--- a/src/programs/pkcheck.c
++++ b/src/programs/pkcheck.c
+@@ -363,6 +363,11 @@ main (int argc, char *argv[])
+   local_agent_handle = NULL;
+   ret = 126;
+ 
++  if (argc < 1)
++    {
++      exit(126);
++    }
++
+   /* Disable remote file access from GIO. */
+   setenv ("GIO_USE_VFS", "local", 1);
+ 
+--- a/src/programs/pkexec.c
++++ b/src/programs/pkexec.c
+@@ -488,6 +488,15 @@ main (int argc, char *argv[])
+   pid_t pid_of_caller;
+   gpointer local_agent_handle;
+ 
++
++  /*
++   * If 'pkexec' is called THIS wrong, someone's probably evil-doing. Don't be nice, just bail out.
++   */
++  if (argc<1)
++    {
++      exit(127);
++    }
++
+   ret = 127;
+   authority = NULL;
+   subject = NULL;
+@@ -614,10 +623,10 @@ main (int argc, char *argv[])
+ 
+       path = g_strdup (pwstruct.pw_shell);
+       if (!path)
+-	{
++        {
+           g_printerr ("No shell configured or error retrieving pw_shell\n");
+           goto out;
+-	}
++        }
+       /* If you change this, be sure to change the if (!command_line)
+ 	 case below too */
+       command_line = g_strdup (path);
+@@ -636,7 +645,15 @@ main (int argc, char *argv[])
+           goto out;
+         }
+       g_free (path);
+-      argv[n] = path = s;
++      path = s;
++
++      /* argc<2 and pkexec runs just shell, argv is guaranteed to be null-terminated.
++       * /-less shell shouldn't happen, but let's be defensive and don't write to null-termination
++       */
++      if (argv[n] != NULL)
++      {
++        argv[n] = path;
++      }
+     }
+   if (access (path, F_OK) != 0)
+     {
+GitLab

--- a/sys-auth/polkit/polkit-0.119-r2.ebuild
+++ b/sys-auth/polkit/polkit-0.119-r2.ebuild
@@ -62,6 +62,8 @@ PATCHES=(
 
 	# from https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/35
 	"${FILESDIR}"/35_WIP_Add_duktape_as_javascript_engine.patch
+
+	"${FILESDIR}/polkit-0.120-CVE-2021-4034.patch"
 )
 
 QA_MULTILIB_PATHS="


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

To be cherry-picked to:
* flatcar-3066
* flatcar-3127

Related-To: https://github.com/flatcar-linux/Flatcar/issues/606

CI (:large_blue_circle:): http://localhost:9091/job/os/job/manifest/4708/cldsv/

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
