### PR TITLE
profiles/base: stabilize vim

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -68,3 +68,7 @@ dev-util/checkbashisms
 
 # Keep iproute in sync with kernel version.
 =sys-apps/iproute2-5.15.0 ~amd64 ~arm64
+
+# Required for some CVEs
+=app-editors/vim-8.2.4328 ~amd64 ~arm64
+=app-editors/vim-core-8.2.4328 ~amd64 ~arm64


### PR DESCRIPTION
this is required to pull recent versions of vim which fix CVEs.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

* no changelog required
* to be merged with: https://github.com/flatcar-linux/portage-stable/pull/284