### PR TITLE
Add auditd package and systemd unit

### DIFF
--- a/changelog/changes/2022-02-15-auditd.md
+++ b/changelog/changes/2022-02-15-auditd.md
@@ -1,0 +1,2 @@
+- Added `auditd.service` but left it disabled by default, a custom configuration can be created by removing the `/etc/audit/auditd.conf` and replacing it with an own file ([PR#1636](https://github.com/flatcar-linux/coreos-overlay/pull/1636))
+

--- a/changelog/changes/2022-02-15-auditd.md
+++ b/changelog/changes/2022-02-15-auditd.md
@@ -1,2 +1,2 @@
-- Added `auditd.service` but left it disabled by default, a custom configuration can be created by removing the `/etc/audit/auditd.conf` and replacing it with an own file ([PR#1636](https://github.com/flatcar-linux/coreos-overlay/pull/1636))
+- Added `auditd.service` but left it disabled by default, a custom configuration can be created by removing `/etc/audit/auditd.conf` and replacing it with an own file ([PR#1636](https://github.com/flatcar-linux/coreos-overlay/pull/1636))
 

--- a/sys-process/audit/files/audit-rules.tmpfiles
+++ b/sys-process/audit/files/audit-rules.tmpfiles
@@ -1,5 +1,6 @@
-d   /etc/audit                          -   -   -   -   -
-d   /etc/audit/rules.d                  -   -   -   -   -
-L   /etc/audit/rules.d/00-clear.rules   -   -   -   -   /usr/share/audit/rules.d/00-clear.rules
-L   /etc/audit/rules.d/80-selinux.rules -   -   -   -   /usr/share/audit/rules.d/80-selinux.rules
-L   /etc/audit/rules.d/99-default.rules -   -   -   -   /usr/share/audit/rules.d/99-default.rules
+d   /etc/audit                          750   -   -   -   -
+C   /etc/audit/auditd.conf              640  -   -   -   /usr/share/auditd/auditd.conf
+d   /etc/audit/rules.d                  750   -   -   -   -
+L   /etc/audit/rules.d/00-clear.rules   640   -   -   -   /usr/share/audit/rules.d/00-clear.rules
+L   /etc/audit/rules.d/80-selinux.rules 640   -   -   -   /usr/share/audit/rules.d/80-selinux.rules
+L   /etc/audit/rules.d/99-default.rules 640   -   -   -   /usr/share/audit/rules.d/99-default.rules


### PR DESCRIPTION
# Add auditd package and systemd unit

This includes the `auditd` binary and systemd unit as part of the
distro. While journald is also able to handle logs from the linux audit
subsystem, auditd provides audit-specific capabilities that are
necessary in deployments subject to regulatory compliance.

For one, an administrator is able to configure audit log writing policy
to ensure that logs land on disk and nothing is missed (`flush`). We
wouldn't want such policy through journald as it woudl sync and ensure
all logs which might be undesirable and too resource intensive. In
short, this allows us to configure different management policies for
audit logs compared to general logs.

It allows us to explicitly configure the node's reaction to errors such
as the disk beign full, the disk having other issues or space constraints.

While Flatcar is not Common Criteria certified which would require the
system to shut down if audit logs present issues (not written or
collected), some FedRAMP environments do require actions such as
notifications (which could be achieved via syslog). This can be
explicitly done with auditd as well.


## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
