### PR TITLE
sys-auth/polkit: remove `-Dwith-duktape`

### DIFF
--- a/sys-auth/polkit/polkit-0.120-r2.ebuild
+++ b/sys-auth/polkit/polkit-0.120-r2.ebuild
@@ -86,7 +86,6 @@ src_configure() {
 		-Dos_type=gentoo
 		-Dsession_tracking="$(usex systemd libsystemd-login libelogind)"
 		-Dsystemdsystemunitdir="$(systemd_get_systemunitdir)"
-		-Dwith-duktape=yes
 		$(meson_use introspection)
 		$(meson_use test tests)
 		$(usex pam "-Dpam_module_dir=$(getpam_mod_dir)" '')


### PR DESCRIPTION
this option is superseeds by `js_engine` which defaults to duktape.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

* no changelog required
* tested via https://github.com/flatcar-linux/portage-stable/pull/285
* to be merged with: https://github.com/flatcar-linux/portage-stable/pull/285