### PR TITLE
sys-apps/ignition: prevent races with udev

### DIFF
--- a/changelog/bugfixes/2022-02-16-ignition-udev-race.md
+++ b/changelog/bugfixes/2022-02-16-ignition-udev-race.md
@@ -1,0 +1,1 @@
+- Prevented hitting races when creating filesystems in Ignition, these races caused boot failures like `fsck[1343]: Failed to stat /dev/disk/by-label/ROOT: No such file or directory` when creating a btrfs root filesystem ([PR#35](https://github.com/flatcar-linux/ignition/pull/35))

--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -12,7 +12,7 @@ inherit coreos-go cros-workon systemd udev
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="6d7b4401700c76492c8627030d9dde147f81d5cf" # flatcar-master
+	CROS_WORKON_COMMIT="de4e6cc9bbba4c801424d74c7f271291766aad7a" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in
    https://github.com/flatcar-linux/ignition/pull/35
    to prevent boot failures such as fsck running while udev was still
    processing the disk changes, and thus failing when the /dev/disk/
    symlink is shortly gone.

## How to use

Change to referencing the merge commit before merging this here

Port to all channels

For Stable this also means to pick https://github.com/flatcar-linux/coreos-overlay/pull/1412 and https://github.com/flatcar-linux/coreos-overlay/pull/1453

## Testing done

See linked PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
