### PR TITLE
profiles/coreos: move gnuefi systemd USE flag to target

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -28,10 +28,9 @@ net-analyzer/nmap ncat -system-lua
 # removes mta dependencies
 app-admin/sudo -sendmail
 
-# use lzma which is the default on non-gentoo systems, use gnuefi for
-# bootctl, enable selinux, disable hybrid cgroup as we use the unified
-# mode now
-sys-apps/systemd build curl idn lzma gnuefi selinux -cgroup-hybrid
+# use lzma which is the default on non-gentoo systems, enable selinux,
+# disable hybrid cgroup as we use the unified mode now
+sys-apps/systemd build curl idn lzma selinux -cgroup-hybrid
 net-libs/libmicrohttpd -ssl
 
 # disable kernel config detection and module building

--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -19,8 +19,8 @@ sys-libs/ncurses	minimal
 sys-libs/pam		-berkdb audit
 sys-libs/gdbm		berkdb
 
-# enable journal gateway and container features
-sys-apps/systemd audit importd http nat
+# enable journal gateway, bootctl and container features
+sys-apps/systemd audit gnuefi importd http nat
 
 # epoll is needed for systemd-journal-remote to work. coreos/bugs#919
 net-libs/libmicrohttpd epoll


### PR DESCRIPTION
# profiles/coreos: move gnuefi systemd USE flag to target

SDK bootstrap is failing with:

  Message: sbat-distro (from ID):

  ../systemd-stable-250.3/src/boot/efi/meson.build:189:24: ERROR: Problem encountered: Required sbat-distro option not set and autodetection failed

The gnuefi USE flag controls whether bootctl and systemd-boot are built, but we
only need those on the target. Currently the USE flag is set for SDK as well,
so move it to coreos/targets/generic.

## How to use

Rebootstrap.

## Testing done

CI started: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4861/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
