### PR TITLE
dev-db/sqlite: skip `sqlite3` installation

### DIFF
--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -12,6 +12,7 @@ FEATURES="nodoc noinfo noman"
 # Exclude even more documentation
 # Remove bash-completion files as we don't install bash-completion.
 # Remove locale LC_MESSAGES files.
+# Remove sqlite3 binary installation provided by dev-db/sqlite as we only need the libs.
 INSTALL_MASK="${INSTALL_MASK}
   /usr/sbin/locale-gen
   /usr/share/bash-completion
@@ -19,6 +20,7 @@ INSTALL_MASK="${INSTALL_MASK}
   /usr/share/locale
   /usr/share/zsh
   /var/db/Makefile
+  /usr/bin/sqlite3
 "
 
 # Exclude assorted config files that we can do without


### PR DESCRIPTION
In this PR, we add `/usr/bin/sqlite3` to `INSTALL_MASK` in order to skip `sqlite3` cli installation.

## Testing done

- CI (:large_blue_circle:): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4888/cldsv/

## Note for reviewers

- Not sure we need a changelog entry since sqlite3 has not been introduced yet in an alpha release.

