### PR TITLE
sys-kernel/bootengine: fix containerised builds

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="bced9373ee9f11028b3c9d704fbca3d2e059a4ef" # flatcar-master
+	CROS_WORKON_COMMIT="dac35d0e420ec906189f4350fce2cd995fde1a35" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Bump `CROS_WORKON` to include https://github.com/flatcar-linux/bootengine/pull/36 to fix an issue with dracut in containerised builds.

This fix should be cherry-picked to all active maintenance branches, i.e. `flatcar-3033`, `flatcar-3066`, and `flatcar-3139`.