### PR TITLE
sys-kernel/bootengine: fix containerised builds

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="589e6bec78718a25eaccc46f25d2c59763b91327" # flatcar-master
+	CROS_WORKON_COMMIT="bd97e3baf3369870f16fbcf0d047cd11fa55b85d" # tip of backports-flatcar-3033
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Update CROS_WORKON to point to maintenance branch backports-flatcar-3033 to include flatcar-linux/bootengine#37, fixing an issue with dracut in containerised builds.