### PR TITLE
Accept keyword cleanup for packages from 2015

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -38,7 +38,6 @@ dev-util/patchelf *
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_cttimeout-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_queue-1.0.3 ~arm64
-=net-misc/bridge-utils-1.5 ~arm64
 =net-misc/curl-7.79.1 ~arm64
 
 # needed to force enable iperf for arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -80,4 +80,3 @@ dev-util/patchelf *
 =sys-process/tini-0.18.0 ~arm64
 =virtual/krb5-0-r1 ~arm64
 =virtual/libusb-1-r2 ~arm64
-=x11-libs/pixman-0.32.8 ~arm64


### PR DESCRIPTION
Needs to be merged together with https://github.com/flatcar-linux/portage-stable/pull/299.

CI: http://localhost:9091/job/os/job/manifest/4960/cldsv/