### PR TITLE
build fixes (shim/polkit)

### DIFF
--- a/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
+++ b/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
@@ -46,7 +46,7 @@ DEPEND="
 	amd64? ( sys-apps/iucode_tool )
 	sys-apps/seismograph
 	sys-boot/grub
-	sys-boot/shim
+	amd64? ( sys-boot/shim )
 	sys-firmware/edk2-ovmf
 	sys-fs/btrfs-progs
 	sys-fs/cryptsetup

--- a/sys-auth/polkit/polkit-0.120-r2.ebuild
+++ b/sys-auth/polkit/polkit-0.120-r2.ebuild
@@ -32,7 +32,7 @@ BDEPEND="
 	introspection? ( dev-libs/gobject-introspection )
 "
 DEPEND="
-	dev-lang/duktape
+	dev-lang/duktape:=
 	dev-libs/glib:2
 	dev-libs/expat
 	pam? (


### PR DESCRIPTION
# build fixes (shim/polkit)

* mark sys-boot/shim as amd64 only dependency (the package doesn't build for arm64)
* polkit dependency on duktape needs to be stricter when using binpkgs

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

CI running.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
