### PR TITLE
core-base/oem-azure(-pro): enable earlycon on all platforms

### DIFF
--- a/coreos-base/oem-azure-pro/files/grub.cfg
+++ b/coreos-base/oem-azure-pro/files/grub.cfg
@@ -5,10 +5,12 @@ set oem_id="azure"
 set linux_append="flatcar.autologin"
 
 # Azure only has a serial console.
-serial com0 --speed=115200 --word=8 --parity=no
-terminal_input serial_com0
-terminal_output serial_com0
+serial --unit=0 --speed=115200 --word=8 --parity=no
+terminal_input serial
+terminal_output serial
 
-if [ "$grub_platform" = "pc" ]; then
-  set linux_console="console=ttyS0,115200n8 earlyprintk=ttyS0,115200"
+if [ "$grub_cpu" = arm64 ]; then
+  set linux_console="console=tty1 console=ttyAMA0,115200n8 earlycon=pl011,0xeffec000"
+else
+  set linux_console="console=tty1 console=ttyS0,115200n8 earlyprintk=ttyS0,115200"
 fi

--- a/coreos-base/oem-azure/files/grub.cfg
+++ b/coreos-base/oem-azure/files/grub.cfg
@@ -5,10 +5,12 @@ set oem_id="azure"
 set linux_append="flatcar.autologin"
 
 # Azure only has a serial console.
-serial com0 --speed=115200 --word=8 --parity=no
-terminal_input serial_com0
-terminal_output serial_com0
+serial --unit=0 --speed=115200 --word=8 --parity=no
+terminal_input serial
+terminal_output serial
 
-if [ "$grub_platform" = "pc" ]; then
-  set linux_console="console=ttyS0,115200n8 earlyprintk=ttyS0,115200"
+if [ "$grub_cpu" = arm64 ]; then
+  set linux_console="console=tty1 console=ttyAMA0,115200n8 earlycon=pl011,0xeffec000"
+else
+  set linux_console="console=tty1 console=ttyS0,115200n8 earlyprintk=ttyS0,115200"
 fi


### PR DESCRIPTION
# core-base/oem-azure(-pro): enable earlycon on all platforms

Both architectures and VM generations.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

CI running

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
