### PR TITLE
coreos-devel/mantle: update to latest state

### DIFF
--- a/coreos-devel/mantle/mantle-9999.ebuild
+++ b/coreos-devel/mantle/mantle-9999.ebuild
@@ -11,7 +11,7 @@ COREOS_GO_MOD="vendor"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="dd6625b29b69fc3dca580c284307ee93f8594431" # v0.18.0
+	CROS_WORKON_COMMIT="9018e676ff0ecf55a5600148b06d52847cbd82b0" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This updates the internal kola version that is now used for tests from
the SDK container pipeline.


## How to use

Pick for all channels

Maybe we should set up a GitHub Action for that or do this as part of the nightly submodule update

## Testing done

