### PR TITLE
Accept keyword cleanup for packages from 2016

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -14,7 +14,6 @@
 =dev-lang/yasm-1.3.0-r1 ~arm64
 =dev-libs/libassuan-2.5.1 ~arm64
 =dev-libs/libevent-2.1.8 ~arm64
-=dev-libs/liblinear-210-r1 ~arm64
 =dev-libs/libusb-1.0.21 ~arm64
 
 =dev-perl/Text-Unidecode-1.270.0 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -33,9 +33,6 @@ dev-util/checkbashisms *
 =net-libs/libnetfilter_queue-1.0.3 ~arm64
 =net-misc/curl-7.79.1 ~arm64
 
-# needed to force enable iperf for arm64
-=net-misc/iperf-3.1.3 **
-
 =net-misc/socat-1.7.3.2 ~arm64
 =perl-core/File-Path-2.130.0 ~arm64
 =sec-policy/selinux-base-2.20200818-r2 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -25,9 +25,6 @@
 # needed by arm64-native SDK
 dev-util/checkbashisms *
 
-# needed by arm64-native SDK
-dev-util/patchelf *
-
 =net-dns/c-ares-1.17.2 ~arm64
 =net-firewall/conntrack-tools-1.4.5 ~arm64
 =net-libs/libnetfilter_conntrack-1.0.8 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -17,9 +17,6 @@
 =dev-libs/liblinear-210-r1 ~arm64
 =dev-libs/libusb-1.0.21 ~arm64
 
-# needed to force enable userspace-rcu for arm64
-=dev-libs/userspace-rcu-0.9.1 **
-
 =dev-perl/Text-Unidecode-1.270.0 ~arm64
 
 # needed to force enable bpftool for arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -33,7 +33,6 @@ dev-util/patchelf *
 
 =net-dns/c-ares-1.17.2 ~arm64
 =net-firewall/conntrack-tools-1.4.5 ~arm64
-=net-libs/http-parser-2.6.2 ~arm64
 =net-libs/libnetfilter_conntrack-1.0.8 ~arm64
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_cttimeout-1.0.0-r1 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -37,9 +37,6 @@ dev-util/checkbashisms
 # CVE-2017-8779
 =net-nds/rpcbind-0.2.4-r1 ~amd64 ~arm64
 
-# All versions are ~amd64 and not enabled on arm64
-=sys-apps/nvme-cli-1.1 **
-
 # Upgrade to GCC 10.3.0 to support latest glibc builds
 =sys-devel/binutils-2.37_p1 ~amd64 ~arm64
 =sys-libs/binutils-libs-2.37_p1 ~amd64 ~arm64

--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -10,7 +10,6 @@ dev-libs/openssl	pkcs11
 dev-util/perf		-doc -demangle -tui -ncurses -perl -python
 net-analyzer/tcpdump	-chroot
 net-misc/dhcp	        -server
-net-misc/iperf		threads
 net-misc/ntp            caps
 sys-apps/smartmontools	-daemon -update-drivedb -systemd
 sys-block/parted        device-mapper


### PR DESCRIPTION
Needs to be merged together with https://github.com/flatcar-linux/portage-stable/pull/300.

~Blocked on https://github.com/flatcar-linux/coreos-overlay/pull/1674.~

CI passed: http://localhost:9091/job/os/job/manifest/4965/cldsv/