### PR TITLE
Profile cleanups for updated packages from 2017

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -61,4 +61,3 @@ dev-util/checkbashisms *
 =sys-power/iasl-20200326 ~arm64
 =sys-process/tini-0.18.0 ~arm64
 =virtual/krb5-0-r1 ~arm64
-=virtual/libusb-1-r2 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -50,7 +50,6 @@
 =sys-firmware/edk2-aarch64-18.02 **
 =sys-fs/btrfs-progs-4.19.1 ~arm64
 =sys-fs/quota-4.04-r1 ~arm64
-=sys-libs/efivar-31 ~arm64
 =sys-libs/libselinux-3.1-r2 ~arm64
 =sys-libs/libsemanage-3.1-r1 ~arm64
 =sys-libs/libsepol-3.1 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -44,8 +44,6 @@
 =sys-apps/sandbox-2.12 ~arm64
 =sys-apps/semodule-utils-3.1 ~arm64
 
-=sys-boot/efibootmgr-15 ~arm64
-
 # needed to force enable ipvsadm for arm64
 =sys-cluster/ipvsadm-1.27-r1 **
 

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -54,7 +54,6 @@ dev-util/checkbashisms *
 
 =sys-firmware/edk2-aarch64-18.02 **
 =sys-fs/btrfs-progs-4.19.1 ~arm64
-=sys-fs/lsscsi-0.28 ~arm64
 =sys-fs/quota-4.04-r1 ~arm64
 =sys-libs/efivar-31 ~arm64
 =sys-libs/libselinux-3.1-r2 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -15,8 +15,6 @@
 =dev-libs/libassuan-2.5.1 ~arm64
 =dev-libs/libusb-1.0.21 ~arm64
 
-=dev-perl/Text-Unidecode-1.270.0 ~arm64
-
 # needed to force enable bpftool for arm64
 =dev-util/bpftool-5.15.8 **
 

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -58,4 +58,3 @@
 =sys-libs/libsepol-3.1 ~arm64
 =sys-power/iasl-20200326 ~arm64
 =sys-process/tini-0.18.0 ~arm64
-=virtual/krb5-0-r1 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -40,7 +40,6 @@ dev-util/checkbashisms *
 =sec-policy/selinux-virt-2.20200818-r2 ~arm64
 =sys-apps/checkpolicy-3.1 ~arm64
 
-=sys-apps/man-db-2.7.6.1-r2 ~arm64
 =sys-apps/policycoreutils-3.1-r3 ~arm64
 =sys-apps/kexec-tools-2.0.22 ~arm64
 

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -13,7 +13,6 @@
 
 =dev-lang/yasm-1.3.0-r1 ~arm64
 =dev-libs/libassuan-2.5.1 ~arm64
-=dev-libs/libevent-2.1.8 ~arm64
 =dev-libs/libusb-1.0.21 ~arm64
 
 =dev-perl/Text-Unidecode-1.270.0 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -46,7 +46,6 @@ dev-util/checkbashisms *
 =sys-apps/sandbox-2.12 ~arm64
 =sys-apps/semodule-utils-3.1 ~arm64
 
-=sys-block/thin-provisioning-tools-0.7.0 ~arm64
 =sys-boot/efibootmgr-15 ~arm64
 
 # needed to force enable ipvsadm for arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -21,7 +21,7 @@
 =dev-util/bpftool-5.15.8 **
 
 # needed by arm64-native SDK
-dev-util/checkbashisms *
+=dev-util/checkbashisms-2.21.4 ~arm64
 
 =net-dns/c-ares-1.17.2 ~arm64
 =net-firewall/conntrack-tools-1.4.5 ~arm64

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -31,7 +31,6 @@
 =net-libs/libnetfilter_queue-1.0.3 ~arm64
 =net-misc/curl-7.79.1 ~arm64
 
-=net-misc/socat-1.7.3.2 ~arm64
 =perl-core/File-Path-2.130.0 ~arm64
 =sec-policy/selinux-base-2.20200818-r2 ~arm64
 =sec-policy/selinux-base-policy-2.20200818-r2 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -12,9 +12,6 @@
 =dev-lang/rust-1.58.1 ~amd64 ~arm64
 =virtual/rust-1.58.1 ~amd64 ~arm64
 
-# no version marked stable upstream
-dev-util/checkbashisms
-
 =dev-libs/elfutils-0.178 ~amd64
 
 =dev-libs/libgcrypt-1.9.4 ~amd64 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -31,9 +31,6 @@
 
 =net-nds/openldap-2.4.58 ~amd64 ~arm64
 
-# CVE-2017-8779
-=net-nds/rpcbind-0.2.4-r1 ~amd64 ~arm64
-
 # Upgrade to GCC 10.3.0 to support latest glibc builds
 =sys-devel/binutils-2.37_p1 ~amd64 ~arm64
 =sys-libs/binutils-libs-2.37_p1 ~amd64 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -43,9 +43,6 @@ dev-util/checkbashisms
 
 =sys-fs/cryptsetup-2.4.1-r1 ~amd64 ~arm64
 
-# Pick up fixes for bugs introduced in 4.0
-=sys-fs/dosfstools-4.1 ~amd64 ~arm64
-
 =sys-fs/multipath-tools-0.8.5 ~amd64 ~arm64
 
 =sys-libs/libseccomp-2.5.0 ~amd64 ~arm64

--- a/profiles/coreos/targets/generic/package.provided
+++ b/profiles/coreos/targets/generic/package.provided
@@ -5,7 +5,7 @@
 # disable them and we have no need/use for them in prod images.
 
 # pulled in by app-crypt/pinentry
-app-eselect/eselect-pinentry-0.7
+app-eselect/eselect-pinentry-0.7.2
 
 # pulled in by app-editors/vim
 app-eselect/eselect-vi-1.2


### PR DESCRIPTION
Usual cleanup of profiles for package updates, 2017 edition.

~Blocked on #1678.~

Needs to be merged together with https://github.com/flatcar-linux/portage-stable/pull/301.

CI: http://localhost:9091/job/os/job/manifest/5080/cldsv/