### PR TITLE
sys-kernel: Revert change to forbid using xfrm id 0

### DIFF
--- a/changelog/bugfixes/2022-03-02-kernel-ipsec-id0-revert.md
+++ b/changelog/bugfixes/2022-03-02-kernel-ipsec-id0-revert.md
@@ -1,0 +1,1 @@
+- Reverted the Linux kernel change to forbid xfrm id 0 for IPSec state because it broke Cilium ([Flatcar#626](https://github.com/flatcar-linux/Flatcar/issues/626), [PR#1682](https://github.com/flatcar-linux/coreos-overlay/pull/1682))

--- a/sys-kernel/coreos-sources/coreos-sources-5.15.25.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-5.15.25.ebuild
@@ -36,4 +36,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
 	${PATCH_DIR}/z0003-PCI-hv-Make-the-code-arch-neutral-by-adding-arch-spe.patch \
 	${PATCH_DIR}/z0004-PCI-hv-Add-arm64-Hyper-V-vPCI-support.patch \
+	${PATCH_DIR}/z0005-Revert-xfrm-state-and-policy-should-fail-if-XFRMA_IF.patch \
 "

--- a/sys-kernel/coreos-sources/files/5.15/z0005-Revert-xfrm-state-and-policy-should-fail-if-XFRMA_IF.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0005-Revert-xfrm-state-and-policy-should-fail-if-XFRMA_IF.patch
@@ -1,0 +1,67 @@
+From 509a0cc7c909899d76b2d7b0afd0124966358515 Mon Sep 17 00:00:00 2001
+From: Kai Lueke <kailuke@microsoft.com>
+Date: Mon, 28 Feb 2022 19:40:26 +0100
+Subject: [PATCH 2/2] Revert "xfrm: state and policy should fail if XFRMA_IF_ID
+ 0"
+
+This reverts commit 68ac0f3810e76a853b5f7b90601a05c3048b8b54 because it
+breaks userspace (e.g., Cilium is affected because it used id 0 for the
+dummy state https://github.com/cilium/cilium/pull/18789).
+
+Signed-off-by: Kai Lueke <kailuke@microsoft.com>
+---
+ net/xfrm/xfrm_user.c | 21 +++------------------
+ 1 file changed, 3 insertions(+), 18 deletions(-)
+
+diff --git a/net/xfrm/xfrm_user.c b/net/xfrm/xfrm_user.c
+index 8cd6c8129004..be89a8ac54a4 100644
+--- a/net/xfrm/xfrm_user.c
++++ b/net/xfrm/xfrm_user.c
+@@ -630,13 +630,8 @@ static struct xfrm_state *xfrm_state_construct(struct net *net,
+ 
+ 	xfrm_smark_init(attrs, &x->props.smark);
+ 
+-	if (attrs[XFRMA_IF_ID]) {
++	if (attrs[XFRMA_IF_ID])
+ 		x->if_id = nla_get_u32(attrs[XFRMA_IF_ID]);
+-		if (!x->if_id) {
+-			err = -EINVAL;
+-			goto error;
+-		}
+-	}
+ 
+ 	err = __xfrm_init_state(x, false, attrs[XFRMA_OFFLOAD_DEV]);
+ 	if (err)
+@@ -1432,13 +1427,8 @@ static int xfrm_alloc_userspi(struct sk_buff *skb, struct nlmsghdr *nlh,
+ 
+ 	mark = xfrm_mark_get(attrs, &m);
+ 
+-	if (attrs[XFRMA_IF_ID]) {
++	if (attrs[XFRMA_IF_ID])
+ 		if_id = nla_get_u32(attrs[XFRMA_IF_ID]);
+-		if (!if_id) {
+-			err = -EINVAL;
+-			goto out_noput;
+-		}
+-	}
+ 
+ 	if (p->info.seq) {
+ 		x = xfrm_find_acq_byseq(net, mark, p->info.seq);
+@@ -1751,13 +1741,8 @@ static struct xfrm_policy *xfrm_policy_construct(struct net *net, struct xfrm_us
+ 
+ 	xfrm_mark_get(attrs, &xp->mark);
+ 
+-	if (attrs[XFRMA_IF_ID]) {
++	if (attrs[XFRMA_IF_ID])
+ 		xp->if_id = nla_get_u32(attrs[XFRMA_IF_ID]);
+-		if (!xp->if_id) {
+-			err = -EINVAL;
+-			goto error;
+-		}
+-	}
+ 
+ 	return xp;
+  error:
+-- 
+2.35.1
+


### PR DESCRIPTION
The changes broke userspace (e.g., Cilium is affected because it used
id 0 for the dummy state https://github.com/cilium/cilium/pull/18789)
and we decided to revert them to give the affected software more time
to adapt (cf. https://marc.info/?t=164607426900002&r=1&w=2).


## How to use

Test that, e.g.,
```
sudo ip link add ipsec0  type xfrm dev lo
```
works again.

Backport to all channels

## Testing done

[Ongoing](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5006/cldsv/)

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
