### PR TITLE
containerd: Enable SELinux labeling support by default

### DIFF
--- a/app-emulation/containerd/files/config.toml
+++ b/app-emulation/containerd/files/config.toml
@@ -27,6 +27,10 @@ runtime = "runc"
 # live restore is not supported
 no_shim = false
 
+[plugins."io.containerd.grpc.v1.cri"]
+# enable SELinux labeling
+enable_selinux = true
+
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
 # setting runc.options unsets parent settings
 runtime_type = "io.containerd.runc.v2"

--- a/changelog/changes/2022-03-08-containerd-selinux.md
+++ b/changelog/changes/2022-03-08-containerd-selinux.md
@@ -1,0 +1,2 @@
+- Made SELinux enabled by default in default containerd configuration file. ([PR#1699](https://github.com/flatcar-linux/coreos-overlay/pull/1699))
+


### PR DESCRIPTION
# containerd: Enable SELinux labeling by default

This enables containerd to do appropriate SELinux labeling of containers
and files by default. This should not be problematic as Flatcar ships with
SELinux permissive by default.

This was based on the [sample config](https://github.com/containerd/cri/blob/deprecated/master/docs/config.md) provided by containerd