### PR TITLE
coreos-base/coreos: remove rng-tool dependency

### DIFF
--- a/changelog/changes/2022-03-09-rngd.md
+++ b/changelog/changes/2022-03-09-rngd.md
@@ -1,0 +1,1 @@
+- Removed rngd.service because it is not essential anymore for the kernel to boot fast in VM environments ([PR#1700](https://github.com/flatcar-linux/coreos-overlay/pull/1700))

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -164,7 +164,6 @@ RDEPEND="${RDEPEND}
 	sys-apps/nvme-cli
 	sys-apps/pciutils
 	sys-apps/policycoreutils
-	sys-apps/rng-tools
 	sys-apps/sed
 	sys-apps/seismograph
 	sys-apps/semodule-utils

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -44,9 +44,6 @@ dev-util/checkbashisms *
 =sys-apps/policycoreutils-3.1-r3 ~arm64
 =sys-apps/kexec-tools-2.0.22 ~arm64
 
-# needed to force enable rng-tools for arm64
-=sys-apps/rng-tools-5-r2 **
-
 =sys-apps/sandbox-2.12 ~arm64
 =sys-apps/semodule-utils-3.1 ~arm64
 


### PR DESCRIPTION
# coreos-base/coreos: remove rng-tool dependency

rng-tools does not appear to be necessary for booting in virtual machine
environments in 2022. Back in the day the boot process would block if
there was not enough entropy to seed the system random pool, but over
the years the linux kernel made sure that the pool is force seeded if
userspace does not do so one it's own. Remove rng-tool as it is not
needed and it would require work to make sure it works (detection of
tpm/hwrng/intel cpu instructions).

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
