### PR TITLE
ignition: support `gce` as OEM ID

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="d993da38542849664417e9eb775b89e712b09586" # flatcar-master
+	CROS_WORKON_COMMIT="2231de798a7393dd8e864ff2ee5409484a81c1d3" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="820a5ad998832cfb06c17df0e61766028f7417eb" # flatcar-master
+	CROS_WORKON_COMMIT="ba5efbf119ff6983bed5c92e0984f59f208f6e94" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

It solves the booting issue on GCP with new version of Ignition.

This pulls:
* https://github.com/flatcar-linux/bootengine/pull/39
* https://github.com/flatcar-linux/init/pull/64

Not released yet - no changelog required.

CI (:large_blue_circle:): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5069/cldsv/