### PR TITLE
sys-apps/systemd: enable systemd-sysext.service

### DIFF
--- a/changelog/changes/2022-03-10-systemd-sysext-service.md
+++ b/changelog/changes/2022-03-10-systemd-sysext-service.md
@@ -1,0 +1,1 @@
+- Enabled the `systemd-sysext.service` by default, to disable you have to mask it

--- a/sys-apps/systemd/systemd-250.3.ebuild
+++ b/sys-apps/systemd/systemd-250.3.ebuild
@@ -560,6 +560,8 @@ multilib_src_install_all() {
 	if use gnuefi; then
 		builddir_systemd_enable_service sysinit.target systemd-boot-update.service
 	fi
+	# Flatcar: enable systemd-sysext.service
+	builddir_systemd_enable_service sysinit.target systemd-sysext.service
 	# Flatcar: enable reboot.target (not enabled - has no WantedBy
 	# entry)
 


### PR DESCRIPTION
The systemd-sysext.service activates sysext images on boot.
Enable it by default.

## How to use

Check that it is on

## Testing done
Manually booted the image and check that the service got started (enabled is not show here because Flatcar uses hardcoded symlinks)
```
$ systemctl status --no-pager systemd-sysext
○ systemd-sysext.service - Merge System Extension Images into /usr/ and /opt/
     Loaded: loaded (/usr/lib/systemd/system/systemd-sysext.service; disabled; vendor preset: disabled)
     Active: inactive (dead)
  Condition: start condition failed at Thu 2022-03-10 17:31:01 UTC; 18s ago
       Docs: man:systemd-sysext.service(8)

Mar 10 17:31:01 localhost systemd[1]: Merge System Extension Images into /usr/ and /opt/ was skipped because all trigger condition checks failed.
```

[started](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5092/cldsv/) but failed because I removed the other branch too early

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
