### PR TITLE
sys-apps/ignition: fix link translation

### DIFF
--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -12,7 +12,7 @@ inherit coreos-go cros-workon systemd udev
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="e2a714474441b416693430e6080e7900d8dd14f0" # main
+	CROS_WORKON_COMMIT="cb95c51122f5a95cea4ed042677933c588fded18" # main
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/ignition/pull/38
for https://github.com/flatcar-linux/ign-converter/pull/5
to fix https://github.com/flatcar-linux/Flatcar/issues/666 which
is about a failing translation due to a too strict check.


## How to use
Check that the following CLC works
```
storage:
  files:
    - path: /helloworld
  links:
    - path: /hello
      target: /helloworld
```

## Testing done

[test build](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5093/cldsv/) and passing the above config worked. A new [kola test](https://github.com/flatcar-linux/mantle/pull/306) passed, too

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ Not needed, we didn't release v3 support yet