### PR TITLE
changelog: add security changelog for Go 1.17.8

### DIFF
--- a/changelog/security/2022-03-11-go-1.17.8.md
+++ b/changelog/security/2022-03-11-go-1.17.8.md
@@ -1,0 +1,1 @@
+- go ([CVE-2022-24921](https://nvd.nist.gov/vuln/detail/CVE-2022-24921))


### PR DESCRIPTION
Add missing security changelog CVE-2022-24921 for Go 1.17.8, done via PR https://github.com/flatcar-linux/coreos-overlay/pull/1697.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
