### PR TITLE
Add sssd to list of SELinux modules enabled

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -58,7 +58,7 @@ sys-libs/glibc nscd
 dev-libs/cyrus-sasl kerberos -berkdb -gdbm
 
 # don't build manpages for sssd
-sys-auth/sssd -python samba kerberos gssapi ssh sudo
+sys-auth/sssd -python samba kerberos gssapi ssh sudo selinux
 
 # enable logging command-line options in update_engine
 dev-cpp/glog gflags


### PR DESCRIPTION
# Include `sssd` SELinux module in base policy

sssd it being provided by flatcar and it was missing from the list.

This inclusion should appropriately label sssd-related files.

Related-Bug: https://github.com/flatcar-linux/Flatcar/issues/673

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
