### PR TITLE
sys-kernel/coreos-sources: revert commit which breaks networking on M4 instances

### DIFF
--- a/changelog/bugfixes/2022-03-14-kernel-msi-revert.md
+++ b/changelog/bugfixes/2022-03-14-kernel-msi-revert.md
@@ -1,0 +1,1 @@
+- Reverted the Linux kernel commit which broke networking on AWS instances which use Intel 82559 NIC (c4/m4) ([Flatcar#665](https://github.com/flatcar-linux/Flatcar/issues/665), [PR#1720](https://github.com/flatcar-linux/coreos-overlay/pull/1720))

--- a/sys-kernel/coreos-sources/coreos-sources-5.10.105.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-5.10.105.ebuild
@@ -35,4 +35,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch \
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
 	${PATCH_DIR}/z0005-Revert-xfrm-state-and-policy-should-fail-if-XFRMA_IF.patch \
+	${PATCH_DIR}/z0006-PCI-MSI-Mask-MSI-X-vectors-only-on-success.patch \
 "

--- a/sys-kernel/coreos-sources/files/5.10/z0006-PCI-MSI-Mask-MSI-X-vectors-only-on-success.patch
+++ b/sys-kernel/coreos-sources/files/5.10/z0006-PCI-MSI-Mask-MSI-X-vectors-only-on-success.patch
@@ -1,0 +1,47 @@
+From 8b59175b0aa9f4a3521f57a35ec53d10741e5aa1 Mon Sep 17 00:00:00 2001
+From: Jeremi Piotrowski <jpiotrowski@microsoft.com>
+Date: Mon, 14 Mar 2022 08:47:44 +0000
+Subject: [PATCH] Revert "PCI/MSI: Mask MSI-X vectors only on success"
+
+With the original commit m4 instances on AWS, which use Intel 82559 VFs for
+networking, are not able to perform any networking (not even DHCP).
+
+This reverts commit e5949933f313c9e2c30ba05b977a047148b5e38c.
+---
+ drivers/pci/msi.c | 13 +++----------
+ 1 file changed, 3 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/pci/msi.c b/drivers/pci/msi.c
+index e11530cb0569..412d818d7ada 100644
+--- a/drivers/pci/msi.c
++++ b/drivers/pci/msi.c
+@@ -721,6 +721,9 @@ static int msix_capability_init(struct pci_dev *dev, struct msix_entry *entries,
+ 		goto out_disable;
+ 	}
+ 
++	/* Ensure that all table entries are masked. */
++	msix_mask_all(base, tsize);
++
+ 	ret = msix_setup_entries(dev, base, entries, nvec, affd);
+ 	if (ret)
+ 		goto out_disable;
+@@ -747,16 +750,6 @@ static int msix_capability_init(struct pci_dev *dev, struct msix_entry *entries,
+ 	/* Set MSI-X enabled bits and unmask the function */
+ 	pci_intx_for_msi(dev, 0);
+ 	dev->msix_enabled = 1;
+-
+-	/*
+-	 * Ensure that all table entries are masked to prevent
+-	 * stale entries from firing in a crash kernel.
+-	 *
+-	 * Done late to deal with a broken Marvell NVME device
+-	 * which takes the MSI-X mask bits into account even
+-	 * when MSI-X is disabled, which prevents MSI delivery.
+-	 */
+-	msix_mask_all(base, tsize);
+ 	pci_msix_clear_and_set_ctrl(dev, PCI_MSIX_FLAGS_MASKALL, 0);
+ 
+ 	pcibios_free_irq(dev);
+-- 
+2.32.0
+


### PR DESCRIPTION
# sys-kernel/coreos-sources: revert commit which breaks networking on M4 instances

We bisected m4 networking failure down to a commit that has already been backported to all stable kernels. Revert the commit while upstream discussions happen.



## How to use

If the ami from the test run is still around:
```
./bin/kola spawn --aws-type m4.large --board amd64-usr  --aws-iam-profile jenkins-test --platform=aws  --aws-ami=ami-03ecf733c5ca3afeb --aws-region=us-west-2 --verbose --aws-credentials-file ~/.aws/credentials
```

## Testing done

Successfully tested here: http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/aws/1242/tapResults/.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
