### PR TITLE
sys-kernel/bootengine: re-add missing modules

### DIFF
--- a/changelog/bugfixes/2022-03-14-readd-initramfs-kernel-modules.md
+++ b/changelog/bugfixes/2022-03-14-readd-initramfs-kernel-modules.md
@@ -1,0 +1,1 @@
+- Re-added the `brd drbd nbd rbd xen-blkfront zram libarc4 lru_cache zsmalloc` kernel modules to the initramfs since they were missing compared to the Flatcar 3033.2.x releases where the 5.10 kernel is used ([PR#40](https://github.com/flatcar-linux/bootengine))

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="ba5efbf119ff6983bed5c92e0984f59f208f6e94" # flatcar-master
+	CROS_WORKON_COMMIT="b5c1672098bccd66c2366f2ec456fabfd0d5bcea" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/bootengine/pull/40
to add the kernel modules back that disappeared compared to Stable
3033.x.y with the 5.10 kernel.


## How to use

Port to beta, alpha - maybe with a bootengine backport branch

## Testing done

[build passed](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5124/cldsv/), and manual checks in https://github.com/flatcar-linux/bootengine/pull/40

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
