### PR TITLE
sys-kernel/coreos-sources: revert commit which breaks networking on M4 instances

### DIFF
--- a/changelog/bugfixes/2022-03-14-kernel-msi-revert.md
+++ b/changelog/bugfixes/2022-03-14-kernel-msi-revert.md
@@ -1,0 +1,1 @@
+- Reverted the Linux kernel commit which broke networking on AWS instances which use Intel 82559 NIC (c4/m4) ([Flatcar#665](https://github.com/flatcar-linux/Flatcar/issues/665), [PR#1723](https://github.com/flatcar-linux/coreos-overlay/pull/1723))

--- a/sys-kernel/coreos-sources/coreos-sources-5.15.28.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-5.15.28.ebuild
@@ -37,4 +37,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0003-PCI-hv-Make-the-code-arch-neutral-by-adding-arch-spe.patch \
 	${PATCH_DIR}/z0004-PCI-hv-Add-arm64-Hyper-V-vPCI-support.patch \
 	${PATCH_DIR}/z0005-Revert-xfrm-state-and-policy-should-fail-if-XFRMA_IF.patch \
+	${PATCH_DIR}/z0006-Revert-PCI-MSI-Mask-MSI-X-vectors-only-on-success.patch \
 "

--- a/sys-kernel/coreos-sources/files/5.15/z0006-Revert-PCI-MSI-Mask-MSI-X-vectors-only-on-success.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0006-Revert-PCI-MSI-Mask-MSI-X-vectors-only-on-success.patch
@@ -1,0 +1,49 @@
+From e437ea6e5261a12423e55b30bff89df972a47317 Mon Sep 17 00:00:00 2001
+From: Jeremi Piotrowski <jpiotrowski@microsoft.com>
+Date: Tue, 15 Mar 2022 10:46:47 +0000
+Subject: [PATCH] Revert "PCI/MSI: Mask MSI-X vectors only on success"
+
+With the original commit m4 instances on AWS, which use Intel 82559 VFs for
+networking, are not able to perform any networking (not even DHCP).
+
+More context: https://lore.kernel.org/lkml/c4a65b9a-d1e2-bf0d-2519-aac7185931d5@redhat.com/
+
+This reverts commit d8888cdabedf353ab9b5a6af75f70bf341a3e7df.
+---
+ drivers/pci/msi.c | 13 +++----------
+ 1 file changed, 3 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/pci/msi.c b/drivers/pci/msi.c
+index cc4c2b8a5efd..96132d68be1e 100644
+--- a/drivers/pci/msi.c
++++ b/drivers/pci/msi.c
+@@ -721,6 +721,9 @@ static int msix_capability_init(struct pci_dev *dev, struct msix_entry *entries,
+ 		goto out_disable;
+ 	}
+ 
++	/* Ensure that all table entries are masked. */
++	msix_mask_all(base, tsize);
++
+ 	ret = msix_setup_entries(dev, base, entries, nvec, affd);
+ 	if (ret)
+ 		goto out_disable;
+@@ -747,16 +750,6 @@ static int msix_capability_init(struct pci_dev *dev, struct msix_entry *entries,
+ 	/* Set MSI-X enabled bits and unmask the function */
+ 	pci_intx_for_msi(dev, 0);
+ 	dev->msix_enabled = 1;
+-
+-	/*
+-	 * Ensure that all table entries are masked to prevent
+-	 * stale entries from firing in a crash kernel.
+-	 *
+-	 * Done late to deal with a broken Marvell NVME device
+-	 * which takes the MSI-X mask bits into account even
+-	 * when MSI-X is disabled, which prevents MSI delivery.
+-	 */
+-	msix_mask_all(base, tsize);
+ 	pci_msix_clear_and_set_ctrl(dev, PCI_MSIX_FLAGS_MASKALL, 0);
+ 
+ 	pcibios_free_irq(dev);
+-- 
+2.32.0
+


### PR DESCRIPTION
# sys-kernel/coreos-sources: revert commit which breaks networking on M4 instances

This is the same as https://github.com/flatcar-linux/coreos-overlay/pull/1720 but for main. 

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
