### PR TITLE
profiles: disable su USE flag for util-linux

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -143,7 +143,11 @@ sys-apps/iproute2 elf
 # Ideally util-linux should have the su binary, but that is currently not
 # possible, because of a bunch of additional dependencies in SDK like
 # pam_sssd in baselayout.
+#
+# Disable su for util-linux to avoid conflict with sys-apps/shadow, which
+# has its own su binary.
 sys-apps/shadow su
+sys-apps/util-linux -su
 
 # Enable kerberos support for NFS
 net-fs/nfs-utils kerberos nfsv41 nfsv4 junction ldap libmount nfsdcld uuid


### PR DESCRIPTION
As `sys-apps/shadow` has its own su binary, `sys-apps/util-linux` should not have its own su binary. Otherwise, build will simply fail.
Disable su USE flag for util-linux.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/310.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5192/cldsv

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (see https://github.com/flatcar-linux/portage-stable/pull/310)
