### PR TITLE
profiles/base: enable `fips` across the OS

### DIFF
--- a/changelog/changes/2022-03-22-fips.md
+++ b/changelog/changes/2022-03-22-fips.md
@@ -1,0 +1,1 @@
+- Enabled FIPS mode for cryptsetup ([flatcar-linux/coreos-overlay#1747](https://github.com/flatcar-linux/coreos-overlay/pull/1747))

--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -31,6 +31,9 @@ USE="${USE} -zeroconf"
 # No need for OpenMP support in GCC and other apps
 USE="${USE} -openmp"
 
+# Let's enable FIPS support for supported software.
+USE="${USE} fips"
+
 # The git-r3 eclass now depends on curl support, which is used in catalyst.
 BOOTSTRAP_USE="${BOOTSTRAP_USE} curl"
 

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -65,3 +65,6 @@
 
 # LibXML2 is not yet stable, required for CVE
 =dev-libs/libxml2-2.9.13-r1 ~amd64 ~arm64
+
+# FIPS support is still being tested
+=sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -134,8 +134,6 @@ sys-auth/polkit -introspection
 # https://marc.info/?l=gentoo-dev&m=163216172229772&w=2
 net-misc/openssh -bindist
 
-dev-libs/openssl fips
-
 # enables ELF support to e.g. allow tc to handle BPF filters.
 sys-apps/iproute2 elf
 


### PR DESCRIPTION
FIPS features will be enabled for OpenSSL and Cryptsetup.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] https://github.com/flatcar-linux/portage-stable/pull/311

<hr>

Closes: https://github.com/flatcar-linux/Flatcar/issues/537