### PR TITLE
eclass/coreos-go.eclass: strip Go binaries by default

### DIFF
--- a/eclass/coreos-go.eclass
+++ b/eclass/coreos-go.eclass
@@ -56,7 +56,7 @@ go_build() {
 
 	${EGO} build -v \
 		-p "$(makeopts_jobs)" \
-		-ldflags "${GO_LDFLAGS} -extldflags '${LDFLAGS}'" \
+		-ldflags "${GO_LDFLAGS} -s -w -extldflags '${LDFLAGS}'" \
 		${COREOS_GO_MOD:+-mod "${COREOS_GO_MOD}"} \
 		-o "${GOBIN}/${binary_name}" \
 		"${package_name}"


### PR DESCRIPTION
The size contains not only of the /usr partition but also the /boot
partition require that we reduce the size of binaries as much as
possible.
Strip all Go binaries by default.

## How to use
check that tests pass and that it actually reduced the image size and vmlinuz size

## Testing done
[onging](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5220/cldsv/)

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ not needed I think