### PR TITLE
.github/workflows: install lbzip2 to speed up sdk creation

### DIFF
--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+sudo apt-get install -y lbzip2
+
 CORK_VERSION=$(curl -sL https://api.github.com/repos/kinvolk/mantle/releases/latest | jq -r .tag_name | sed -e 's/^v//')
 curl -L -o cork https://github.com/kinvolk/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64
 curl -L -o cork.sig https://github.com/kinvolk/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64.sig


### PR DESCRIPTION
# .github/workflows: install lbzip2 to speed up sdk creation

Our github actions use cork to create an sdk chroot, which pulls down bzipped
archives. The runners have 2 CPUs, so this unpacking could be faster if we
installed lbzip2. Cork transparently uses lbzip2.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
