### PR TITLE
Import virtual/rust to from portage-stable and update the rust workflow

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -44,6 +44,7 @@ function prepare_git_repo() {
   # setup overlay repo inside SDK too (be fork friendly)
   git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" remote add our_remote "${our_remote_url}"
   git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" fetch our_remote
+  git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" checkout -B "${BASE_BRANCH}" "our_remote/${BASE_BRANCH}"
 }
 
 # caller needs to set pass a parameter as a branch name to be created.

--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -61,7 +61,7 @@ function checkout_branches() {
     return 1
   fi
 
-  git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" checkout -B "${TARGET_BRANCH}" "github/${BASE_BRANCH}"
+  git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" checkout -B "${TARGET_BRANCH}" "our_remote/${BASE_BRANCH}"
 }
 
 function regenerate_manifest() {

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -29,6 +29,8 @@ find profiles -name 'package.*' | xargs sed -i "s/\([><]*=\|~\)*virtual\/rust-\S
 
 EBUILD_FILENAME=$(get_ebuild_filename "dev-lang" "rust" "${VERSION_OLD}")
 git mv "${EBUILD_FILENAME}" "dev-lang/rust/rust-${VERSION_NEW}.ebuild"
+EBUILD_FILENAME=$(get_ebuild_filename "virtual" "rust" "${VERSION_OLD}")
+git mv "${EBUILD_FILENAME}" "virtual/rust/rust-${VERSION_NEW}.ebuild"
 
 popd >/dev/null || exit
 

--- a/.github/workflows/rust-release-main.yml
+++ b/.github/workflows/rust-release-main.yml
@@ -40,18 +40,8 @@ jobs:
           branch: rust-${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}-main
           author: Flatcar Buildbot <buildbot@flatcar-linux.org>
           committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
-          title: Upgrade dev-lang/rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
-          commit-message: Upgrade dev-lang/rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          title: Upgrade dev-lang/rust and virtual/rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          commit-message: Upgrade dev-lang/rust and virtual rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
           body: |
-            Upgrade dev-lang/rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
-
-            This PR should be merged together with a corresponding PR in portage-stable for `virtual/rust` ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}.
+            Upgrade dev-lang/rust and virtual/rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
           labels: main
-      - name: Send repository dispatch to portage-stable
-        uses: peter-evans/repository-dispatch@v1.0.0
-        if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
-        with:
-          token: ${{ secrets.FLATCAR_PORTAGE_STABLE_ACCESS_TOKEN }}
-          repository: flatcar-linux/portage-stable
-          event-type: rust-pull-request-main
-          client-payload: '{"coreos-overlay-pull-request-number": "${{ steps.create-pull-request.outputs.pull-request-number }}"}'

--- a/virtual/rust/metadata.xml
+++ b/virtual/rust/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>rust@gentoo.org</email>
+		<name>Rust Project</name>
+	</maintainer>
+	<use>
+		<flag name="rustfmt">Install rustfmt, Rust code formatter</flag>
+	</use>
+	<stabilize-allarches/>
+</pkgmetadata>

--- a/virtual/rust/rust-1.59.0.ebuild
+++ b/virtual/rust/rust-1.59.0.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for Rust language compiler"
+
+LICENSE=""
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="rustfmt"
+
+BDEPEND=""
+RDEPEND="|| (
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+)"


### PR DESCRIPTION
See https://github.com/flatcar-linux/portage-stable/pull/313 for details. This PR updates the workflow to also update the imported virtual/rust package too.

Should be merged together with https://github.com/flatcar-linux/portage-stable/pull/313.

CI: http://localhost:9091/job/os/job/manifest/5241/cldsv/