### PR TITLE
github/workflows: add mantle update action

### DIFF
--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -1,0 +1,76 @@
+name: Get the latest mantle release for branch
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  get-mantle-release:
+    strategy:
+      matrix:
+        branch: [main,alpha,beta,stable]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Figure out branch
+        id: figure-out-branch
+        run: |
+          if [ ${{ matrix.branch }} = "main" ]; then
+            echo ::set-output name=BRANCH::main
+          else
+            major=$(curl -sSL https://${{ matrix.branch }}.release.flatcar-linux.net/amd64-usr/current/version.txt | awk -F= '/FLATCAR_BUILD=/{ print $2 }')
+            echo ::set-output name=BRANCH::flatcar-${major}
+          fi
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ steps.figure-out-branch.outputs.BRANCH }}
+      - name: Fetch latest mantle hash
+        id: fetch-latest-mantle
+        run: |
+          commit=$(git ls-remote  https://github.com/flatcar-linux/mantle refs/heads/flatcar-master | cut -f1)
+          git clone https://github.com/flatcar-linux/mantle
+          pushd mantle
+          version=$(git describe HEAD)
+          version=${version%%-*}
+          version=${version#v}
+          popd
+          rm -rf mantle
+          echo ::set-output name=COMMIT::${commit}
+          echo ::set-output name=VERSION::${version}
+      - name: Try to apply patch
+        run: |
+          set -x
+          commit=${{ steps.fetch-latest-mantle.outputs.COMMIT }}
+          version=${{ steps.fetch-latest-mantle.outputs.VERSION }}
+          pushd coreos-devel/mantle
+          if ! grep -q ${commit} mantle-9999.ebuild; then
+            sed -i -e 's/\(CROS_WORKON_COMMIT\)=".*"/\1="'${commit}'"/' \
+                   -e 's/\(CROS_WORKON_COMMIT=.*\)#.*/\1# flatcar-master/' \
+                   mantle-9999.ebuild
+          fi
+          if ! git diff --quiet ; then
+            link=$(echo mantle-*.*.*.ebuild)
+            if ( echo ${link} | grep -q ${version} ); then
+              # if link contains the correct version then we need to uprev
+              rev=${link#mantle-*-r}
+              rev=${rev%.ebuild}
+              rev=$(( rev + 1 ))
+              newlink=mantle-${version}-r${rev}.ebuild
+              git mv ${link} ${newlink}
+            else
+              git mv ${link} mantle-${version}-r1.ebuild
+            fi
+          fi
+      - name: Create pull request for main
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.figure-out-branch.outputs.BRANCH }}
+          branch: mantle-update-${{ steps.figure-out-branch.outputs.BRANCH }}
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade mantle to latest HEAD in ${{ steps.figure-out-branch.outputs.BRANCH }}
+          commit-message: Update mantle commit to latest HEAD
+          delete-branch: true


### PR DESCRIPTION
# github/workflows: add mantle update action

This action runs over main and the release branches and creates a PR that
updates mantle reference to the latest one. By using a fixed branch name,
rerunning the action will update/close an existing PR if new mantle commits
happen or if the PR becomes obsolete.

## How to use

Wait until merged, and then it will run automatically on each commit or use workflow_dispatch.

## Testing done

Tested here: https://github.com/jepio/coreos-overlay
See this PR: https://github.com/jepio/coreos-overlay/pull/3.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
