### PR TITLE
profiles: delete keywords for gnutls

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -19,8 +19,6 @@
 # needed for arm64 sdk
 =dev-util/pahole-1.20 ~arm64
 
-=net-libs/gnutls-3.7.1 ~amd64 ~arm64
-
 =net-misc/openssh-8.8_p1-r3 ~amd64 ~arm64
 
 =net-misc/rsync-3.2.3-r5 ~amd64 ~arm64


### PR DESCRIPTION
As we update gnutls to 3.7.3-r1 which is already stable, there is no need to accept keywords for gnutls.
Delete.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/315.

## Testing done

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (see https://github.com/flatcar-linux/portage-stable/pull/315)
