### PR TITLE
sys-libs/zlib: Add arches to package.accept_keywords

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -59,6 +59,7 @@
 # Required for some CVEs
 =app-editors/vim-8.2.4328 ~amd64 ~arm64
 =app-editors/vim-core-8.2.4328 ~amd64 ~arm64
+=sys-libs/zlib-1.2.12-r2 ~amd64 ~arm64
 
 # Duktape is not yet stable
 =dev-lang/duktape-2.7.0-r1 ~amd64 ~arm64


### PR DESCRIPTION
# sys-libs/zlib: Add arches to package.accept_keywords

To be merged with https://github.com/flatcar-linux/portage-stable/pull/319

## Testing done

CI Passed http://jenkins.infra.kinvolk.io:8080/job/os/job/board/job/packages-matrix/8698/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
