### PR TITLE
ignition: Enable SELinux relabeling

### DIFF
--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -46,7 +46,7 @@ PATCHES=(
 
 src_compile() {
 	export GO15VENDOREXPERIMENT="1"
-	GO_LDFLAGS="-X github.com/flatcar-linux/ignition/v2/internal/version.Raw=${PV} -X github.com/flatcar-linux/ignition/v2/internal/distro.selinuxRelabel=false -X github.com/flatcar-linux/ignition/v2/internal/distro.writeAuthorizedKeysFragment=false" || die
+	GO_LDFLAGS="-X github.com/flatcar-linux/ignition/v2/internal/version.Raw=${PV} -X github.com/flatcar-linux/ignition/v2/internal/distro.writeAuthorizedKeysFragment=false" || die
 	go_build "${COREOS_GO_PACKAGE}/internal"
 }
 

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="85d325684c5c7817aad230b801f302903e9c6f69" # flatcar-master
+	CROS_WORKON_COMMIT="9479105f044048d2026da04c1a76f42e01343d5e" # setfiles
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
# ignition: Enable SELinux relabeling

This removes the LD Flag that disabled SELinux relabeling. It defaulted to true, thus enabling the feature.

Related Bug: https://github.com/flatcar-linux/Flatcar/issues/673

- [ ] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5307/cldsv/
- [ ] changelog entry