### PR TITLE
coreos-base/coreos-init: skip ensure-sysext unit

### DIFF
--- a/changelog/bugfixes/2022-04-12-skip-ensure-sysext.md
+++ b/changelog/bugfixes/2022-04-12-skip-ensure-sysext.md
@@ -1,0 +1,1 @@
+- Skipped starting `ensure-sysext.service` if `systemd-sysext.service` won't be started, to prevent reporting a dependency failure ([Flatcar#710](https://github.com/flatcar-linux/Flatcar/issues/710))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="d76453b957f1e9ebe428c66ea6c9e3bb9a2d3489" # flatcar-master
+	CROS_WORKON_COMMIT="656181fd8e80fd10f44b8e0ec64998cfd1ff8901" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sys-apps/systemd/CHECKLIST.md
+++ b/sys-apps/systemd/CHECKLIST.md
@@ -1,0 +1,1 @@
+- Check that the `systemd-sysext.service`'s `ConditionDirectoryNotEmpty` entries are correctly reflected in `flatcar-linux/init:systemd/system/ensure-sysext.service`


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/init/pull/68 to skip
the ensure-sysext unit when systemd-sysext is skipped to prevent a
dependency failure being reported.

Closes: https://github.com/flatcar-linux/Flatcar/issues/710


## How to use

backport to flatcar-3185 and -3200


## Testing done

Booted the built image and checked that `ensure-sysext.service was skipped because all trigger condition checks failed`

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
