### PR TITLE
sys-apps/ignition: pull Azure IMDS

### DIFF
--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -12,7 +12,7 @@ inherit coreos-go cros-workon systemd udev
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="cb95c51122f5a95cea4ed042677933c588fded18" # main
+	CROS_WORKON_COMMIT="1d3355cb78f01c6b520e8bbe39ab745fe422c0ed" # tormath1/azuredata
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

This pulls:
* https://github.com/flatcar-linux/ignition/pull/39

Related to:
* https://github.com/flatcar-linux/Flatcar/issues/656
* https://github.com/flatcar-linux/mantle/pull/321

- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5455/cldsv/ (tested with: https://github.com/flatcar-linux/mantle/pull/321)
- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)

<hr>

### Test results

* instance provisioned with userdata
```
Apr 19 16:32:11.673605 ignition[538]: GET http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text: attempt #1
Apr 19 16:32:11.688769 ignition[538]: GET result: OK
Apr 19 16:32:11.688797 ignition[538]: config has been read from IMDS userdata
Apr 19 16:32:11.688804 ignition[538]: parsing config with SHA512: 408ae5130749bba01375dd4812f527fbd81ca8bd2dada0287021e6430f34d3506acc80e5e7c3d7016ca9aa0265241a6ce44f4bb45c5881962ac578b8ad526515
Apr 19 16:32:11.693339 ignition[538]: fetch: fetch complete
Apr 19 16:32:11.693352 ignition[538]: fetch: fetch passed
```

* instance provisioned without userdata
```
Apr 19 18:30:43.330967 ignition[543]: GET http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text: attempt #1
Apr 19 18:30:43.344247 ignition[543]: GET result: OK
Apr 19 18:30:43.344265 ignition[543]: failed to retrieve userdata from IMDS, falling back to custom data: not a config (empty)
Apr 19 18:30:43.409410 ignition[543]: opening config device: "/dev/sr0"
Apr 19 18:30:43.414170 ignition[543]: getting drive status for "/dev/sr0"
Apr 19 18:30:43.414669 ignition[543]: drive status: OK
Apr 19 18:30:43.415178 ignition[543]: mounting config device
Apr 19 18:30:43.415190 ignition[543]: op(1): [started]  mounting "/dev/sr0" at "/tmp/ignition-azure3235375659"
Apr 19 18:30:43.468316 ignition[543]: op(1): [finished] mounting "/dev/sr0" at "/tmp/ignition-azure3235375659"
Apr 19 18:30:43.468326 ignition[543]: checking for config drive
Apr 19 18:30:43.472786 ignition[543]: reading config
Apr 19 18:30:43.474332 ignition[543]: op(2): [started]  unmounting "/dev/sr0" at "/tmp/ignition-azure3235375659"
Apr 19 18:30:43.477642 systemd[1]: tmp-ignition\x2dazure3235375659.mount: Deactivated successfully.
Apr 19 18:30:43.480588 ignition[543]: op(2): [finished] unmounting "/dev/sr0" at "/tmp/ignition-azure3235375659"
Apr 19 18:30:43.480606 ignition[543]: config has been read from custom data
Apr 19 18:30:43.486960 ignition[543]: parsing config with SHA512: a739ae28c4923f03256d96a2d71006c025f5c15a93a8bf267f2c537aadf957e838171973d7fae302664a2574ac3cace21547e99215ab43205925e941ce1f8c41
Apr 19 18:30:43.492200 ignition[543]: fetch: fetch complete
```