### PR TITLE
profiles: accept keywords ~arm64 for app-arch/libarchive 3.6.1

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -1,6 +1,8 @@
 # arm64 keywords
 # Keep these in alphabetical order.
 
+=app-arch/libarchive-3.6.1 ~arm64
+
 # needed by arm64-native SDK
 =app-emulation/open-vmdk-1.0 *
 =app-crypt/rhash-1.4.2 ~arm64


### PR DESCRIPTION
Accept keywords ~arm64 for app-arch/libarchive 3.6.1.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/322.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5410/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (see https://github.com/flatcar-linux/portage-stable/pull/322)
