### PR TITLE
sys-kernel/bootengine: rework afterburn hostname setup

### DIFF
--- a/changelog/changes/2022-04-13-hostname-setup-with-afterburn.md
+++ b/changelog/changes/2022-04-13-hostname-setup-with-afterburn.md
@@ -1,0 +1,2 @@
+- Azure: Set up `/etc/hostname` from instance metadata with Afterburn
+- AWS EC2: Removed the setup of `/etc/hostname` from the instance metadata because it used a long FQDN but we can just use use the hostname set via DHCP ([Flatcar#707](https://github.com/flatcar-linux/Flatcar/issues/707))

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="85d325684c5c7817aad230b801f302903e9c6f69" # flatcar-master
+	CROS_WORKON_COMMIT="110ddbf154f73a98e378f698eb40354d2429ec92" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/bootengine/pull/43
to remove the afterburn /etc/hostname setup for EC2 and align the
afterburn /etc/hostname setup with upstream.


## How to use

Test that the EC2 hostname gets set as expected, check that the DigitalOcean and Packet hostnames get set as expected

## Testing done


- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
