### PR TITLE
coreos-base/coreos-init: add systemd-sysext.service for OEM mount

### DIFF
--- a/changelog/bugfixes/2022-04-14-systemd-sysext-oem-mount.md
+++ b/changelog/bugfixes/2022-04-14-systemd-sysext-oem-mount.md
@@ -1,0 +1,1 @@
+- Added a remount action as `systemd-sysext.service` drop-in unit to restore the OEM partition mount after the overlay mounts in `/usr` are done ([PR#69](https://github.com/flatcar-linux/init/pull/69))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="538e67b821846b788dab5563203d9ce9dba5c0cf" # flatcar-master
+	CROS_WORKON_COMMIT="40af7f1424c0a3de90306c5c9957c12722aa89dc" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar-linux/init/pull/69
to restore the OEM partition mount point after the /usr overlay is
done.

## How to use
backport to flatcar-3185 and -3200

## Testing done

Tested with https://github.com/flatcar-linux/mantle/pull/324 (`/mantle/branch-builder/PR-324` and `systemd.sysext.simple`)

- Successfully tested on [qemu, gce, vmware esx, and azure](http://192.168.42.7:8080/job/os/job/manifest/5426/cldsv/) (a new build was started to test after rebasing) and manually as mentioned in the other PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
