### PR TITLE
profiles: add keywords to cross-*/binutils as well

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -30,6 +30,11 @@
 # Upgrade to GCC 10.3.0 to support latest glibc builds
 =sys-devel/binutils-2.37_p1 ~amd64 ~arm64
 =sys-libs/binutils-libs-2.37_p1 ~amd64 ~arm64
+# This needs to be kept in-sync otherwise dev container contains
+# different binutils than was used by crossdev to build kernel
+# which breaks kmod builds
+=cross-x86_64-cros-linux-gnu/binutils-2.37_p1 ~amd64
+=cross-aarch64-cros-linux-gnu/binutils-2.37_p1 ~arm64
 
 =sys-fs/cryptsetup-2.4.1-r1 ~amd64 ~arm64
 


### PR DESCRIPTION
# profiles: add keywords to cross-*/binutils as well

Crossdev currently uses binutils 2.36 (stable), while the SDK and sysroot both
build binutils 2.37 due to keywording. Kernel modules built within the
developer container fail to load due to relocation errors. Add the same
keywords to cross-*/binutils packages so that the versions match.

- [ ] https://github.com/flatcar-linux/scripts/pull/286

## How to use

Perform at least a stage4 bootstrap with sdk-new. Doesn't affect update_chroot because that prefers binpkgs in all cases.

## Testing done

Still testing in CI.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
