### PR TITLE
Add missing pahole dependencies

### DIFF
--- a/changelog/bugfixes/2022-04-25-fix-dev-container-module-builds.md
+++ b/changelog/bugfixes/2022-04-25-fix-dev-container-module-builds.md
@@ -1,0 +1,1 @@
+- Added pahole to developer container, without it kernel modules built against /usr/src/linux may fail to probe with an 'invalid relocation target' error ([PR#1839](https://github.com/flatcar-linux/coreos-overlay/pull/1839))

--- a/coreos-base/coreos-dev/coreos-dev-0.1.0.ebuild
+++ b/coreos-base/coreos-dev/coreos-dev-0.1.0.ebuild
@@ -21,6 +21,7 @@ RDEPEND="
 	coreos-base/emerge-gitclone
 	dev-lang/python
 	dev-util/strace
+	dev-util/pahole
 	dev-vcs/repo
 	net-analyzer/netperf
 	net-dialup/minicom

--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -35,6 +35,7 @@ SLOT="0/${PVR}"
 SRC_URI=""
 IUSE=""
 
+BDEPEND="dev-util/pahole"
 DEPEND="=sys-kernel/coreos-sources-${COREOS_SOURCE_VERSION}"
 
 # Do not analyze or strip installed files

--- a/sys-kernel/coreos-sources/coreos-sources-5.15.35.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-5.15.35.ebuild
@@ -24,6 +24,9 @@ else
 	PATCH_DIR="${FILESDIR}/${KV_MAJOR}.${KV_MINOR}"
 fi
 
+# make modules_prepare depends on pahole
+RDEPEND="dev-util/pahole"
+
 KEYWORDS="amd64 arm64"
 IUSE=""
 


### PR DESCRIPTION
# Add missing pahole dependencies

pahole is a build-time dependency of our kernel build, due to us setting
CONFIG_BTF_DEBUG_INFO. If pahole is missing, a `make modules_prepare` with our
kernel config results in symbols in the config changing. This will affect
people building kernel modules against coreos-sources in the developer
container, but not the SDK because pahole is already in sdk-depends.

## How to use

Test the resulting developer container with nvidia.service on a GPU instance (e.g. NC6s_v3 in EastUS).

## Testing done

Modified this line: https://github.com/flatcar-linux/coreos-overlay/blob/main/x11-drivers/nvidia-drivers/files/bin/install-nvidia#L7 to be `emerge -gkv pahole coreos-sources` and verified that this allows the built modules to be probed. Without this, the module fails to load with this error message "module: x86/modules: Skipping invalid relocation target, existing value is nonzero for type 1...".

Tested here: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5487/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
`