### PR TITLE
Move mantle's dnsmasq dependency to the SDK dependencies

### DIFF
--- a/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
+++ b/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
@@ -37,6 +37,7 @@ DEPEND="
 	dev-util/patchelf
 	dev-vcs/repo
 	net-dns/bind-tools
+	>=net-dns/dnsmasq-2.72[dhcp,ipv6]
 	net-libs/rpcsvc-proto
 	net-misc/curl
 	sys-apps/debianutils


### PR DESCRIPTION
The removal of the mantle ebuild file also meant that dnsmasq isn't
installed into the SDK anymore, yet we actually need it to run kola
QEMU tests in the SDK on the original CI pipeline. As long as the
original CI pipeline is kept, we have to keep kola's dependencies
like QEMU and dnsmasq around.


## How to use

Build an SDK and run the kola tests from it with the original pipeline.
When merged this should fix the nightly failure.

Backport to all channels (incl 2605, 3033)

## Testing done

[here](http://192.168.42.7:8080/job/os/job/manifest/5509/cldsv/)
