### PR TITLE
sys-kernel/bootengine: pull network kargs

### DIFF
--- a/changelog/changes/2022-05-12-bootengine.md
+++ b/changelog/changes/2022-05-12-bootengine.md
@@ -1,0 +1,1 @@
+- Added VMware networking configuration in the initramfs via guestinfo settings ([bootengine#44](https://github.com/flatcar-linux/bootengine/pull/44), [flatcar#717](https://github.com/flatcar-linux/Flatcar/issues/717))

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="cb9e1a86cc979b72820f4ec6e14704df88bc9a2b" # flatcar-master
+	CROS_WORKON_COMMIT="39caefd1da35d3600120b44ea5ee23ed22129b46" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

This pulls the following PR:
* https://github.com/flatcar-linux/bootengine/pull/44

To be tested with:
* https://github.com/flatcar-linux/mantle/pull/329

Closes: https://github.com/flatcar-linux/Flatcar/issues/717

- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5619/cldsv/
- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
