### PR TITLE
profiles: accept keywords for git 2.35.3

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -63,3 +63,6 @@
 
 # FIPS support is still being tested
 =sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64
+
+# Required for CVE-2022-24765
+=dev-vcs/git-2.35.3 ~amd64 ~arm64


### PR DESCRIPTION
We need to build 2.35.3 to address [CVE-2022-24765](https://nvd.nist.gov/vuln/detail/CVE-2022-24765).

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/325.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5571/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (see https://github.com/flatcar-linux/portage-stable/pull/325)
