### PR TITLE
profiles: accept keywords for net-misc/rsync

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -19,7 +19,8 @@
 
 =net-misc/openssh-8.8_p1-r3 ~amd64 ~arm64
 
-=net-misc/rsync-3.2.3-r5 ~amd64 ~arm64
+# Required for addressing CVE-2018-25032 in its bundled zlib
+=net-misc/rsync-3.2.4-r1 ~amd64 ~arm64
 
 # To address security issues like CVE-2021-31879, we need to accept
 # keywords for wget 1.21.2.


### PR DESCRIPTION
We need to allow `net-misc/rsync` 3.2.4-r1, to address security issues in its bundled zlib.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/326.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5572/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (see https://github.com/flatcar-linux/portage-stable/pull/326) 
