### PR TITLE
sys-kernel/bootengine: bump commit ID

### DIFF
--- a/changelog/bugfixes/2022-05-22-bootengine.md
+++ b/changelog/bugfixes/2022-05-22-bootengine.md
@@ -1,0 +1,1 @@
+- Fixed Ignition's OEM ID to be `metal` to follow the Ignition upstream change which otherwise resulted in a broken boot when the Flatcar OEM ID `pxe` was used ([bootengine#45](https://github.com/flatcar-linux/bootengine/pull/45))

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="110ddbf154f73a98e378f698eb40354d2429ec92" # flatcar-master
+	CROS_WORKON_COMMIT="cb9e1a86cc979b72820f4ec6e14704df88bc9a2b" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
this pulls:
* https://github.com/flatcar-linux/bootengine/pull/45

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

On Matrix, we got a report of a user unable to boot Flatcar with Ignition on a bare metal setup. By default `pxe` is set by `ignition-generator` but with recent Ignition upgrade, we need to update `pxe` to `metal`.

Not sure how we could test this except manually :thinking: it has been confirmed on Matrix that `flatcar.oem.id=metal` fixes the issue.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)

TODO: Backport on : 
* flatcar-3227
* flatcar-3185