### PR TITLE
coreos-base/coreos-init: Ensure /etc/flatcar/update.conf exists

### DIFF
--- a/changelog/bugfixes/2022-05-11-create-etc-flatcar-update.conf.md
+++ b/changelog/bugfixes/2022-05-11-create-etc-flatcar-update.conf.md
@@ -1,0 +1,1 @@
+- Ensured `/etc/flatcar/update.conf` exists because it happens to be used as flag file for Ansible ([init#71](https://github.com/flatcar-linux/init/pull/71))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="40af7f1424c0a3de90306c5c9957c12722aa89dc" # flatcar-master
+	CROS_WORKON_COMMIT="33858a125b2a180254343839ed432e20a0cddaca" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/init/pull/71
to create /etc/flatcar/update.conf if missing.


## How to use

Backport to all channels (may need to use the init backport branches)

## Testing done

Checked the the built image doesn't have the file but it gets created on first boot and any other boot if it doesn't exist. Also checked that writing `/etc/coreos/update.conf` with Ignition will populate this file.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
