### PR TITLE
profiles: Work around the build-id collisions

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -78,9 +78,11 @@ CONFIG_PROTECT="
 
 # Remove libtool .la files for non-plugin libraries.
 # Remove Gentoo init files since we use systemd.
+# Remove build-id, there is some issue with it causing collisions.
 INSTALL_MASK="
   /usr/lib*/*.la
   /etc/init.d /etc/conf.d
+  /usr/lib/debug/.build-id
 "
 
 # Keep the default languages small.


### PR DESCRIPTION
Just don't install the build-id files. Tested in http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5625/cldsv/