### PR TITLE
Enable arm64 version of sssd

### DIFF
--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -80,7 +80,6 @@ RDEPEND="${RDEPEND}
 		app-emulation/xenstore
 		net-fs/cifs-utils
 		sys-auth/realmd
-		sys-auth/sssd
 	)"
 
 RDEPEND="${RDEPEND}
@@ -170,6 +169,7 @@ RDEPEND="${RDEPEND}
 	sys-apps/usbutils
 	sys-apps/util-linux
 	sys-apps/which
+	sys-auth/sssd
 	sys-block/open-iscsi
 	sys-block/parted
 	sys-cluster/ipvsadm


### PR DESCRIPTION
# Enable arm64 version of sssd

Enable arm64 version of sssd

## How to use

Verify that sssd is cross-compiled for arm64

This may be dependent on the samba changes in https://github.com/flatcar-linux/coreos-overlay/pull/1819

I'm following the guidance from https://github.com/flatcar-linux/Flatcar/issues/689#issuecomment-1124969883

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
