### PR TITLE
profiles: accept keywords ~arm64 for curl 7.83.1

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -24,7 +24,7 @@
 =net-firewall/conntrack-tools-1.4.6-r1 ~arm64
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_cttimeout-1.0.0-r1 ~arm64
-=net-misc/curl-7.79.1 ~arm64
+=net-misc/curl-7.83.1 ~arm64
 
 =perl-core/File-Path-2.130.0 ~arm64
 =sec-policy/selinux-base-2.20200818-r2 ~arm64


### PR DESCRIPTION
To be able to build curl 7.83.1 for arm64, we need to accept keywords for `~arm64`.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/330.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5663/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (see https://github.com/flatcar-linux/portage-stable/pull/330)
