### PR TITLE
coreos-base/hard-host-depends: Drop dev-python/pylint

### DIFF
--- a/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
+++ b/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
@@ -105,7 +105,6 @@ RDEPEND="${RDEPEND}
 # Host dependencies for python
 RDEPEND="${RDEPEND}
 	dev-python/docutils
-	dev-python/pylint
 	"
 
 # Host dependencies to scp binaries from the binary component server


### PR DESCRIPTION
It does not seem to be a build dependency of python.

This is an experiment. I'm trying to see if I can drop a one possibly unused python package (and its dependencies), so https://github.com/flatcar-linux/portage-stable/pull/329 could be smaller.

Should be merged together with PORTAGE_STABLE_PR.

CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5676/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
