### PR TITLE
sys-power/acpid: new package

### DIFF
--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -188,6 +188,7 @@ RDEPEND="${RDEPEND}
 	sys-libs/glibc
 	sys-libs/nss-usrfiles
 	sys-libs/timezone-data
+	sys-power/acpid
 	sys-process/lsof
 	sys-process/procps
 	x11-drivers/nvidia-metadata

--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -79,10 +79,12 @@ CONFIG_PROTECT="
 # Remove libtool .la files for non-plugin libraries.
 # Remove Gentoo init files since we use systemd.
 # Remove build-id, there is some issue with it causing collisions.
+# Remove default files from sys-power/acpid.
 INSTALL_MASK="
   /usr/lib*/*.la
   /etc/init.d /etc/conf.d
   /usr/lib/debug/.build-id
+  /etc/acpi
 "
 
 # Keep the default languages small.

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -64,3 +64,5 @@
 
 # Required for CVE-2022-24765
 =dev-vcs/git-2.35.3 ~amd64 ~arm64
+
+=sys-power/acpid-2.0.33 ~amd64 ~arm64


### PR DESCRIPTION
Add `sys-power/acpid` to the explicit list of Flatcar's packages.

## Testing done

- CI(:green_heart:): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5710/cldsv/

<hr>

Closes: https://github.com/flatcar-linux/Flatcar/issues/738

changelog in `::portage-stable`
