### PR TITLE
coreos-base/oem-gce: bring back shutdown scripts

### DIFF
--- a/changelog/bugfixes/2022-05-23-gcp-shutdown.md
+++ b/changelog/bugfixes/2022-05-23-gcp-shutdown.md
@@ -1,0 +1,1 @@
+- GCP: Fixed shutdown script execution ([coreos-overlay#1912](https://github.com/flatcar-linux/coreos-overlay/pull/1912), [flatcar#743](https://github.com/flatcar-linux/Flatcar/issues/743))

--- a/coreos-base/oem-gce/files/units/oem-gce.service
+++ b/coreos-base/oem-gce/files/units/oem-gce.service
@@ -25,7 +25,7 @@ ExecStartPre=/usr/bin/umount /var/lib/flatcar-oem-gce.img
 Environment=SYSTEMD_NSPAWN_API_VFS_WRITABLE=1
 ExecStart=/usr/bin/systemd-nspawn --keep-unit --register=no --link-journal=no \
     --machine=oem-gce --capability=CAP_NET_ADMIN --bind=/dev/log --bind=/run/systemd --tmpfs=/run/lock --bind=/etc --bind=/home --bind-ro=/usr/share/google-oslogin/nsswitch.conf \
-    --read-only --volatile=overlay --image=/var/lib/flatcar-oem-gce.img /init.sh
+    --read-only --volatile=overlay --image=/var/lib/flatcar-oem-gce.img --kill-signal=SIGTERM /init.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In the [`init.sh`](https://github.com/flatcar-linux/coreos-overlay/blob/main/coreos-base/coreos-oem-gce/files/manglefs.sh) of the OEM GCE container, we have the following
section:

```bash
wait -n "${daemon_pids[@]}" || :
kill "${daemon_pids[@]}" || :

test -n "$stopping" || exit 1

exec /usr/bin/google_metadata_script_runner --script-type shutdown
```

`shutdown` script was not executed because container was receiving a
`SIGKILL`, the started processes was not properly terminated.

According to the `systemd-nspawn` manual:
```bash
If --boot is not used and this option is not specified
the container's processes are terminated abruptly via SIGKILL
```

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>


## Testing done

Added a `shutdown-script` to the GCP metadata server, edited the `oem-gce` to add the `--kill-signal=SIGTERM`, manually stopped the service and see the `shutdown-script` being executed in the logs:
```bash
Trying to halt container. Send SIGTERM again to trigger immediate termination.
++ stopping=1
++ kill 30 31 32
+ :
+ kill 30 31 32
+ test -n 1
+ exec /usr/bin/google_metadata_script_runner --script-type shutdown
Stopping GCE Linux Agent...
INFO Starting shutdown scripts.
INFO Found shutdown-script in metadata.
INFO shutdown-script: Return code 0.
INFO Finished running shutdown scripts.
Container oem-gce exited successfully.
oem-gce.service: Deactivated successfully.
Stopped GCE Linux Agent.
oem-gce.service: Consumed 4.964s CPU time.
```

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)


Closes: https://github.com/flatcar-linux/Flatcar/issues/743