### PR TITLE
profiles: delete libxml2 keywords

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -56,9 +56,6 @@
 # Duktape is not yet stable
 =dev-lang/duktape-2.7.0-r1 ~amd64 ~arm64
 
-# LibXML2 is not yet stable, required for CVE
-=dev-libs/libxml2-2.9.13-r1 ~amd64 ~arm64
-
 # FIPS support is still being tested
 =sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64
 


### PR DESCRIPTION
Now that `dev-libs/libxml2` 2.9.14 is stable, we do not need to accept keywords for that.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/333.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5814/cldsv/

-  Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (see https://github.com/flatcar-linux/portage-stable/pull/333)
