### PR TITLE
Add ARM64 support for cifs-utils, realmd, sssd, adcli, go-tspi

### DIFF
--- a/changelog/changes/2022-06-10-arm64-cifsutils-realmd-sssd-adcli-gotspi.md
+++ b/changelog/changes/2022-06-10-arm64-cifsutils-realmd-sssd-adcli-gotspi.md
@@ -1,0 +1,3 @@
+- ARM64: Added [sssd](https://sssd.io/), [adcli](https://www.freedesktop.org/software/realmd/adcli/adcli.html) and realmd for ARM64
+- ARM64: Added [cifs-utils](https://wiki.samba.org/index.php/LinuxCIFS_utils) for ARM64
+- SDK / ARM64: Added [go-tspi](https://pkg.go.dev/github.com/coreos/go-tspi) bindings for ARM64

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -74,15 +74,12 @@ RDEPEND="${RDEPEND}
 # Only applicable or available on amd64
 RDEPEND="${RDEPEND}
 	amd64? (
-		app-admin/adcli
-		app-crypt/go-tspi
 		app-emulation/xenserver-pv-version
 		app-emulation/xenstore
-		net-fs/cifs-utils
-		sys-auth/realmd
 	)"
 
 RDEPEND="${RDEPEND}
+	app-admin/adcli
 	app-admin/etcd-wrapper
 	app-admin/flannel-wrapper
 	app-admin/locksmith
@@ -101,6 +98,7 @@ RDEPEND="${RDEPEND}
 	app-arch/unzip
 	app-arch/zip
 	app-crypt/gnupg
+	app-crypt/go-tspi
 	app-crypt/tpmpolicy
 	app-editors/vim
 	app-emulation/actool
@@ -129,6 +127,7 @@ RDEPEND="${RDEPEND}
 	net-firewall/iptables
 	net-firewall/nftables
 	net-fs/nfs-utils
+	net-fs/cifs-utils
 	net-misc/bridge-utils
 	net-misc/curl
 	net-misc/iputils
@@ -169,6 +168,7 @@ RDEPEND="${RDEPEND}
 	sys-apps/usbutils
 	sys-apps/util-linux
 	sys-apps/which
+	sys-auth/realmd
 	sys-auth/sssd
 	sys-block/open-iscsi
 	sys-block/parted

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -80,7 +80,6 @@ RDEPEND="${RDEPEND}
 		app-emulation/xenstore
 		net-fs/cifs-utils
 		sys-auth/realmd
-		sys-auth/sssd
 	)"
 
 RDEPEND="${RDEPEND}
@@ -170,6 +169,7 @@ RDEPEND="${RDEPEND}
 	sys-apps/usbutils
 	sys-apps/util-linux
 	sys-apps/which
+	sys-auth/sssd
 	sys-block/open-iscsi
 	sys-block/parted
 	sys-cluster/ipvsadm

--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -48,3 +48,6 @@
 =sys-libs/libsepol-3.1 ~arm64
 =sys-power/iasl-20200326 ~arm64
 =sys-process/tini-0.18.0 ~arm64
+
+# Overwrite portage-stable mask - enable ding-libs for ARM64
+=dev-libs/ding-libs-0.6.1-r1 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -63,3 +63,6 @@
 =dev-vcs/git-2.35.3 ~amd64 ~arm64
 
 =sys-power/acpid-2.0.33 ~amd64 ~arm64
+
+# Overwrite portage-stable mask - use latest liburing -r2 for ARM64 and AMD64
+=sys-libs/liburing-2.1-r2 ~amd64 ~arm64


### PR DESCRIPTION
This change adds multiple tools to ARM64 which were formerly only
present in the X86-64 image.

Added for ARM64:

        net-fs/cifs-utils
        sys-auth/realmd
        sys-auth/sssd
        app-admin/adcli
        app-crypt/go-tspi

This leaves only the xenserver-pv-version and xenstore packages exclusively on X86-64.

The change un-masks keywords `amd64` and `arm64` for `sys-libs/liburing-2.1-r2` and keyword `arm64` for `dev-libs/ding-libs-0.6.1-r1`, overwriting Gentoo upstream defaults in portage-stable.

Partially fixes https://github.com/flatcar-linux/Flatcar/issues/689.
Fixes https://github.com/flatcar-linux/Flatcar/issues/690.

Requires https://github.com/flatcar-linux/portage-stable/pull/334 .

## How to use

Check out branch. Build the image.
```shell
./run_sdk_container -t 
   ./ build_packages --board=arm64-usr
   ./build_image --board=arm64-usr
   ./image_to_vm.sh ...
```

Then launch the image and check for binaries / libraries.
```shell
./flatcar_production_qemu_uefi.sh
[...]
core@localhost ~ $ sssd --version
2.3.1
core@localhost ~ $ sudo -i
root@localhost ~ # /usr/libexec/realmd --help
Usage:
  realmd [OPTION?] realmd
[...]
root@localhost ~ # adcli
usage: adcli command <args>...
[...]
root@localhost ~ # cifs.upcall -v
version: 6.13
```

## Testing done

Built the image locally and checked for binaries.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
