### PR TITLE
Init bump

### DIFF
--- a/changelog/changes/2022-06-12-uefibootentry.md
+++ b/changelog/changes/2022-06-12-uefibootentry.md
@@ -1,0 +1,1 @@
+- flatcar-install: Added option to create UEFI boot entry ([init#74](https://github.com/flatcar-linux/init/pull/74))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="33858a125b2a180254343839ed432e20a0cddaca" # flatcar-master
+	CROS_WORKON_COMMIT="7497ac210fcb85d7670b86e21726ffe1b23549a0" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
# Bump init

Bump init to add an option to flatcar-install in order to create the UEFI flatcar boot entry

- [ ] Bump flatcar init
