### PR TITLE
coreos-base/coreos-init: Remove outdated LTS motd information

### DIFF
--- a/changelog/bugfixes/2022-06-30-remove-outdated-lts-motd.md
+++ b/changelog/bugfixes/2022-06-30-remove-outdated-lts-motd.md
@@ -1,0 +1,1 @@
+- Removed outdated LTS channel information printed on login ([init#75](https://github.com/flatcar-linux/init/pull/75))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="a4f4ec3a1fab6a75f12c39ddf53da6eef9fbd098" # flatcar-master
+	CROS_WORKON_COMMIT="b99ff0626f5983af7aee47e95f34991d42f68e5b" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/init/pull/75
to update the LTS info that is printed on login.

To be backported to 3033 (and 2605 if possible)

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
