### PR TITLE
sys-devel/binutils: Add the accept_keywords for binutils, binutils-lib

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -27,13 +27,13 @@
 =net-misc/wget-1.21.2 ~amd64 ~arm64
 
 # Upgrade to GCC 10.3.0 to support latest glibc builds
-=sys-devel/binutils-2.37_p1 ~amd64 ~arm64
-=sys-libs/binutils-libs-2.37_p1 ~amd64 ~arm64
+=sys-devel/binutils-2.38-r2 ~amd64 ~arm64
+=sys-libs/binutils-libs-2.38-r2 ~amd64 ~arm64
 # This needs to be kept in-sync otherwise dev container contains
 # different binutils than was used by crossdev to build kernel
 # which breaks kmod builds
-=cross-x86_64-cros-linux-gnu/binutils-2.37_p1 ~amd64
-=cross-aarch64-cros-linux-gnu/binutils-2.37_p1 ~arm64
+=cross-x86_64-cros-linux-gnu/binutils-2.38-r2 ~amd64
+=cross-aarch64-cros-linux-gnu/binutils-2.38-r2 ~arm64
 
 =sys-fs/cryptsetup-2.4.1-r1 ~amd64 ~arm64
 


### PR DESCRIPTION
# sys-devel/binutils: Add the accept_keywords for binutils, binutils-lib

To be merged with https://github.com/flatcar-linux/portage-stable/pull/341

## Testing done
Jenkins CI passed: 
~http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5947/cldsv/~ 
~http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6053/cldsv/~
http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6054/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
