### PR TITLE
net-fs/cifs-utils: Add the package.accept_keywords for cifs-utils

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -68,3 +68,6 @@
 =sys-libs/liburing-2.1-r2 ~amd64 ~arm64
 
 =app-crypt/adcli-0.9.1-r2 ~amd64 ~arm64
+
+# Required for CVE-2022-27239, CVE-2022-29869
+=net-fs/cifs-utils-6.15 ~amd64 ~arm64


### PR DESCRIPTION
# net-fs/cifs-utils: Add the package.accept_keywords for cifs-utils

Sync with Gentoo upstream to address the CVE, CVE-2022-27239, CVE-2022-29869

To be merged with https://github.com/flatcar-linux/portage-stable/pull/342

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5953/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
