### PR TITLE
sys-kernel/bootengine: Fix ignition kargs support by creating grub.cfg

### DIFF
--- a/changelog/bugfixes/2022-07-13-ignition-kargs.md
+++ b/changelog/bugfixes/2022-07-13-ignition-kargs.md
@@ -1,0 +1,1 @@
+- The Ignition v3 kargs directive failed before when used with the generic image where no `grub.cfg` exists, this was fixed by creating it first ([bootengine#47](https://github.com/flatcar-linux/bootengine/pull/47))

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="39caefd1da35d3600120b44ea5ee23ed22129b46" # flatcar-master
+	CROS_WORKON_COMMIT="95bb406972f1846945e8e355ab98cafa570f273f" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/bootengine/pull/47
which creates the grub.cfg file if it does not exist when the Ignition
kargs directive is used, preventing an error when it tried to read the
current settings from it.


## How to use

Can be backported when using bootengine branches

## Testing done

see PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
