### PR TITLE
Record SLSA provenance data

### DIFF
--- a/profiles/coreos/base/profile.bashrc
+++ b/profiles/coreos/base/profile.bashrc
@@ -94,6 +94,9 @@ cros_pre_pkg_setup_sysroot_build_bin_dir() {
 	PATH+=":${CROS_BUILD_BOARD_BIN}"
 }
 
+# Source hooks for SLSA build provenance report generation
+source "${BASH_SOURCE[0]}.slsa-provenance"
+
 # Insert our sysroot wrappers into the path
 SYSROOT_WRAPPERS_BIN="/usr/lib64/sysroot-wrappers/bin"
 if [[ "$PATH" != *"$SYSROOT_WRAPPERS_BIN"* ]]; then

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -1,0 +1,181 @@
+# Build provenance hooks
+# ======================
+# The functions below hook into every ebuild's execution and generate provenance files
+#   to meet the SLSA provenance requirements (https://slsa.dev/spec/v0.1/requirements#available).
+# All input files (source tarball / git commit hash) plus added patches / files,
+#   and all resulting installation binaries and files are captured.
+# The information is emitted in SLSA provenance 0.2 format (see https://slsa.dev/provenance/v0.2)
+
+
+# We only record provenance when a package is actually being built.
+# See profiles/coreos/base/profile.bashrc for cros_...
+cros_post_src_configure_enable_slsa_provenance_report() {
+    export __slsa_provenance_report="yes"
+}
+# --
+
+# Generate SLSA provenance 0.2 Subject information.
+# The information will cover all installation files shipped with a package.
+__slsa_provenance_subject() {
+    local parallel="$(grep -cE '^processor' /proc/cpuinfo)"
+    local comma=""
+
+    einfo "    Provenance: recording subject (output)"
+
+    echo '   "subject": ['
+
+    (
+        cd "$D"
+        find . -type f -print | sed 's:^./::' | xargs -P "$parallel" -L 1 sha512sum
+    ) | while read checksum filepath; do
+        echo -en "${comma}     {\"name\":\"/$filepath\", \"digest\":{\"sha512\":\"$checksum\"}}"
+        if [ -z "$comma" ] ; then
+            comma=',\n'
+        fi
+    done
+   echo -en "\n   ]"
+}
+# --
+
+__slsa_provenance_materials() {
+    local csum="" uri="" repo="" ebuild=""
+
+    local ebuilds_basedir="/mnt/host/source/src/third_party/"
+    local ebuild="${CATEGORY}/${PN}/${PF}.ebuild"
+    if [ -f "${ebuilds_basedir}/coreos-overlay/${ebuild}" ] ; then
+        repo="coreos-overlay"
+    elif [ -f "${ebuilds_basedir}/portage-stable/${ebuild}" ] ; then
+        repo="portage-stable"
+    else
+        eerror "SLSA provenance: Unable to detect ebuild repository for package '${ebuild}'"
+        exit 1
+    fi
+
+    einfo "    Provenance: recording ebuild material (input) '${repo}/${ebuild}'"
+    echo '   "materials": ['
+
+    # The ebuild. Since "configSource" in "invocation" cannot have more than one (top/level) entry
+    #  we add the ebuild and git repo checksum here, as a material.
+    csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/ORIG_HEAD")"
+    uri="git+https://github.com/flatcar-linux/${repo}.git/${ebuild}"
+    echo -e "      { \"uri\": \"${uri}\","
+    echo -n "        \"digest\": {\"sha1\":\"${csum}\"} }"
+
+    # The main sources
+    if [ -n "${A}" ] ; then
+        # Package is built from downloaded source tarball(s)
+        # There can be multiple, and can be used conditionally based on use flags,
+        #  and even replaced with different local names ("http://... -> othername.tgz"). So
+        #  we go through what's actually used ($A), then find the corresponding source URI.
+        local src="" prev_uri="" rename="false" orig_name=""
+        for src in ${A}; do
+            local found="false"
+            for uri in ${SRC_URI}; do
+                if [ "${uri}" = "->" ] ; then
+                    rename="true"
+                    continue
+                fi
+                if [ "${src}" = "$(basename "${uri}")" ] ; then
+                    orig_name="${src}"
+                    if [ "${rename}" = "true" ] ; then
+                        uri="${prev_uri}"
+                        orig_name="$(basename "${uri}")"
+                    fi
+                    einfo "    Provenance: recording tarball material (input) '${src}' ('${orig_name}')"
+                    csum="$(sha512sum "${DISTDIR}/${src}" | cut -d' ' -f1)"
+                    echo -e ",\n      { \"uri\": \"${uri}\","
+                    echo -n "        \"digest\": {\"sha512\":\"${csum}\"} }"
+                    found="true"
+                fi
+                rename="false"
+                prev_uri="${uri}"
+            done
+            if [ "${found}" != "true" ] ; then
+                eerror "No SRC_URI found for source '${src}', unable to record provenance!"
+                exit 1
+            fi
+        done
+    elif [ -n "${EGIT_REPO_URI:-}" ] ; then
+        # package is built from repo checkout (git)
+        einfo "    Provenance: recording GIT material (input) '${EGIT_REPO_URI}'"
+        csum="${EGIT_COMMIT}"
+        uri="${EGIT_REPO_URI}"
+        echo -e ",\n      { \"uri\": \"${uri}\","
+        echo -n "        \"digest\": {\"sha1\":\"$csum\"} }"
+    fi
+
+    # Patches / files shipped with the ebuild (if any)
+    uri="git+https://github.com/flatcar-linux/${repo}.git/${CATEGORY}/${PN}/files"
+    csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/ORIG_HEAD")"
+    if [ -d "${FILESDIR}" ] ; then
+        for file in $(cd "$FILESDIR" && find . -type f | sed 's:^./::') ; do
+            einfo "    Provenance: recording ebuild material (input) '${file}'"
+            echo -e ",\n      { \"uri\": \"${uri}/${file}\","
+            echo -n "        \"digest\": {\"sha1\":\"$csum\"} }"
+        done
+    fi
+
+    echo -ne '\n   ]'
+}
+# --
+
+__slsa_provenance_report() {
+    local scripts_hash="$(cat "/mnt/host/source/src/scripts/.git/ORIG_HEAD")"
+    local buildcmd="emerge"
+    # extract board from e.g. '/build/amd64-usr/build'. Empty if no board is set (SDK build).
+    local board="$(echo "${CROS_BUILD_BOARD_TREE:-}" | sed -n 's:^/build/\([^/]\+\)/.*:\1:p')"
+    if [ -n "$board" ] ; then
+        buildcmd="emerge-${board}"
+    fi
+
+    # FIXME: Supply SDK image ID and sha256 digest along with the version tag
+    local sdk_version="$(source /mnt/host/source/.repo/manifests/version.txt; echo ${FLATCAR_SDK_VERSION})"
+
+    # FIXME: add builder ID
+cat <<EOF
+{
+ "_type": "https://in-toto.io/Statement/v0.1",
+ "predicateType": "https://slsa.dev/provenance/v0.2",
+ "predicate": {
+   "buildType": "ghcr.io/flatcar-linux/flatcar-sdk-all:${sdk_version}",
+   "builder": {"id": "TODO - builder ID" },
+   "invocation": {
+      "configSource": {
+        "uri": "https://github.com/flatcar-linux/scripts",
+        "digest": {"sha1": "${scripts_hash}"}
+      }
+   },
+   "buildConfig": {
+     "commands": [
+        "git checkout ${scripts_hash}",
+        "git submodule init",
+        "git submodule update",
+        "./run_sdk_container ${buildcmd} =${CATEGORY}/${PF}"
+    ]
+   },
+EOF
+    __slsa_provenance_materials
+    echo ","
+    __slsa_provenance_subject
+    echo ""
+cat <<EOF
+  }
+}
+EOF
+}
+# --
+
+cros_post_src_install_generate_slsa_provenance_report() {
+    if [ "${__slsa_provenance_report:-no}" != "yes" ] ; then
+        return
+    fi
+
+    mkdir -p "$D/usr/share/SLSA/"
+    local report_file="${CATEGORY}_${PF}.json.xz"
+    local dest_dir="${D}/usr/share/SLSA/"
+
+    __slsa_provenance_report | xz -9cz > "${T}/${report_file}"
+
+    mkdir -p "${dest_dir}"
+    mv "${T}/${report_file}" "${dest_dir}"
+}

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -131,12 +131,15 @@ __slsa_provenance_materials() {
 # --
 
 __slsa_provenance_report() {
-    local scripts_hash="$(cat "/mnt/host/source/src/scripts/.git/ORIG_HEAD")"
+    local scripts_hash="$(cat "/mnt/host/source/src/scripts/.git/HEAD")"
     local buildcmd="emerge"
     # extract board from e.g. '/build/amd64-usr/build'. Empty if no board is set (SDK build).
     local board="$(echo "${CROS_BUILD_BOARD_TREE:-}" | sed -n 's:^/build/\([^/]\+\)/.*:\1:p')"
     if [ -n "$board" ] ; then
         buildcmd="emerge-${board}"
+    fi
+    if [[ "${scripts_hash}" == "ref:"* ]]; then
+        scripts_hash="$(cat /mnt/host/source/src/scripts/.git/${scripts_hash#ref: })"
     fi
 
     # FIXME: Supply SDK image ID and sha256 digest along with the version tag

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -187,7 +187,7 @@ cros_post_src_install_generate_slsa_provenance_report() {
     local report_file="${CATEGORY}_${PF}.json.bz2"
     local dest_dir="${D}/usr/share/SLSA/"
 
-    __slsa_provenance_report | lbzip2 -9cz > "${T}/${report_file}"
+    __slsa_provenance_report | jq | lbzip2 -9cz > "${T}/${report_file}"
 
     mkdir -p "${dest_dir}"
     mv "${T}/${report_file}" "${dest_dir}"

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -58,8 +58,8 @@ __slsa_provenance_materials() {
 
     # The ebuild. Since "configSource" in "invocation" cannot have more than one (top/level) entry
     #  we add the ebuild and git repo checksum here, as a material.
-    csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/ORIG_HEAD")"
-    uri="git+https://github.com/flatcar-linux/${repo}.git/${ebuild}"
+    csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/HEAD")"
+    uri="git+https://github.com/flatcar-linux/${repo}.git@${csum}#${ebuild}"
     echo -e "      { \"uri\": \"${uri}\","
     echo -n "        \"digest\": {\"sha1\":\"${csum}\"} }"
 
@@ -106,10 +106,12 @@ __slsa_provenance_materials() {
     fi
 
     # Patches / files shipped with the ebuild (if any)
-    uri="git+https://github.com/flatcar-linux/${repo}.git/${CATEGORY}/${PN}/files"
-    csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/ORIG_HEAD")"
+    csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/HEAD")"
+    uri="git+https://github.com/flatcar-linux/${repo}.git@${csum}#${CATEGORY}/${PN}/files"
     if [ -d "${FILESDIR}" ] ; then
         for file in $(cd "$FILESDIR" && find . -type f | sed 's:^./::') ; do
+            csum="$(sha1sum - <"${FILESDIR}/${file}")"
+            csum="${csum%% *}"
             einfo "    Provenance: recording ebuild material (input) '${file}'"
             echo -e ",\n      { \"uri\": \"${uri}/${file}\","
             echo -n "        \"digest\": {\"sha1\":\"$csum\"} }"

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -10,6 +10,9 @@
 # We only record provenance when a package is actually being built.
 # See profiles/coreos/base/profile.bashrc for cros_...
 cros_post_src_configure_enable_slsa_provenance_report() {
+    if [ "${GENERATE_SLSA_PROVENANCE:-}" != "true" ] ; then
+        einfo "Provenance generation not requested by build; skipping."
+    fi
     export __slsa_provenance_report="yes"
 }
 # --

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -30,7 +30,7 @@ __slsa_provenance_subject() {
 
     (
         cd "$D"
-        find . -type f -print | sed 's:^./::' | xargs -P "$parallel" -L 1 sha512sum
+        find . -type f -print | sed 's:^./::' | xargs -P "$parallel" -L 1 sha512sum | sort -k2
     ) | while read checksum filepath; do
         echo -en "${comma}     {\"name\":\"/$filepath\", \"digest\":{\"sha512\":\"$checksum\"}}"
         if [ -z "$comma" ] ; then

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -171,11 +171,10 @@ cros_post_src_install_generate_slsa_provenance_report() {
         return
     fi
 
-    mkdir -p "$D/usr/share/SLSA/"
-    local report_file="${CATEGORY}_${PF}.json.xz"
+    local report_file="${CATEGORY}_${PF}.json.bz2"
     local dest_dir="${D}/usr/share/SLSA/"
 
-    __slsa_provenance_report | xz -9cz > "${T}/${report_file}"
+    __slsa_provenance_report | lbzip2 -9cz > "${T}/${report_file}"
 
     mkdir -p "${dest_dir}"
     mv "${T}/${report_file}" "${dest_dir}"

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -42,16 +42,24 @@ __slsa_provenance_subject() {
 # --
 
 __slsa_provenance_materials() {
-    local csum="" uri="" repo="" ebuild=""
+    local csum="" uri="" repo="" ebuild="" ebuildcsum=""
 
     local ebuild="${CATEGORY}/${PN}/${PF}.ebuild"
-    if [ -f "$(portageq get_repo_path ${ROOT:-/} coreos)/${ebuild}" ] ; then
+    local repopath="$(portageq get_repo_path ${ROOT:-/} coreos)"
+    if [ -f "${repopath}/${ebuild}" ] ; then
         repo="coreos-overlay"
-    elif [ -f "$(portageq get_repo_path ${ROOT:-/} portage-stable)/${ebuild}" ] ; then
-        repo="portage-stable"
+        ebuildcsum=$(sha1sum - < "${repopath}/${ebuild}")
     else
+        repopath="$(portageq get_repo_path ${ROOT:-/} portage-stable)"
+        if [ -f "${repopath}/${ebuild}" ] ; then
+            repo="portage-stable"
+            ebuildcsum=$(sha1sum - < "${repopath}/${ebuild}")
+        fi
+    fi
+    if [ -z "${repo}" ]; then
         die "SLSA provenance: Unable to detect ebuild repository for package '${ebuild}'"
     fi
+    ebuildcsum=${ebuildcsum%% *}
 
     einfo "    Provenance: recording ebuild material (input) '${repo}/${ebuild}'"
     echo '   "materials": ['
@@ -61,7 +69,7 @@ __slsa_provenance_materials() {
     csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/HEAD")"
     uri="git+https://github.com/flatcar-linux/${repo}.git@${csum}#${ebuild}"
     echo -e "      { \"uri\": \"${uri}\","
-    echo -n "        \"digest\": {\"sha1\":\"${csum}\"} }"
+    echo -n "        \"digest\": {\"sha1\":\"${ebuildcsum}\"} }"
 
     # The main sources
     if [ -n "${A}" ] ; then

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -14,7 +14,7 @@ cros_post_src_configure_enable_slsa_provenance_report() {
         einfo "Provenance generation not requested by build; skipping."
         return 0
     fi
-    export __slsa_provenance_report="yes"
+    export generate_slsa_provenance_report="yes"
 }
 # --
 
@@ -167,7 +167,7 @@ EOF
 # --
 
 cros_post_src_install_generate_slsa_provenance_report() {
-    if [ "${__slsa_provenance_report:-no}" != "yes" ] ; then
+    if [ "${generate_slsa_provenance_report:-no}" != "yes" ] ; then
         return
     fi
 

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -21,7 +21,7 @@ cros_post_src_configure_enable_slsa_provenance_report() {
 # Generate SLSA provenance 0.2 Subject information.
 # The information will cover all installation files shipped with a package.
 __slsa_provenance_subject() {
-    local parallel="$(grep -cE '^processor' /proc/cpuinfo)"
+    local parallel="$(nproc)"
     local comma=""
 
     einfo "    Provenance: recording subject (output)"

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -12,6 +12,7 @@
 cros_post_src_configure_enable_slsa_provenance_report() {
     if [ "${GENERATE_SLSA_PROVENANCE:-}" != "true" ] ; then
         einfo "Provenance generation not requested by build; skipping."
+        return 0
     fi
     export __slsa_provenance_report="yes"
 }
@@ -49,8 +50,7 @@ __slsa_provenance_materials() {
     elif [ -f "$(portageq get_repo_path ${ROOT:-/} portage-stable)/${ebuild}" ] ; then
         repo="portage-stable"
     else
-        eerror "SLSA provenance: Unable to detect ebuild repository for package '${ebuild}'"
-        exit 1
+        die "SLSA provenance: Unable to detect ebuild repository for package '${ebuild}'"
     fi
 
     einfo "    Provenance: recording ebuild material (input) '${repo}/${ebuild}'"
@@ -93,8 +93,7 @@ __slsa_provenance_materials() {
                 prev_uri="${uri}"
             done
             if [ "${found}" != "true" ] ; then
-                eerror "No SRC_URI found for source '${src}', unable to record provenance!"
-                exit 1
+                die "No SRC_URI found for source '${src}', unable to record provenance!"
             fi
         done
     elif [ -n "${EGIT_REPO_URI:-}" ] ; then

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -43,11 +43,10 @@ __slsa_provenance_subject() {
 __slsa_provenance_materials() {
     local csum="" uri="" repo="" ebuild=""
 
-    local ebuilds_basedir="/mnt/host/source/src/third_party/"
     local ebuild="${CATEGORY}/${PN}/${PF}.ebuild"
-    if [ -f "${ebuilds_basedir}/coreos-overlay/${ebuild}" ] ; then
+    if [ -f "$(portageq get_repo_path ${ROOT:-/} coreos)/${ebuild}" ] ; then
         repo="coreos-overlay"
-    elif [ -f "${ebuilds_basedir}/portage-stable/${ebuild}" ] ; then
+    elif [ -f "$(portageq get_repo_path ${ROOT:-/} portage-stable)/${ebuild}" ] ; then
         repo="portage-stable"
     else
         eerror "SLSA provenance: Unable to detect ebuild repository for package '${ebuild}'"


### PR DESCRIPTION
# Record SLSA provenance data

Add post install hooks to capture provenance metadata for every built package. The hooks are sourced by default by every package built with the coreos/base profile (or inheriting from it), but enabled only when GENERATE_SLSA_PROVENANCE=true is defined. This is intended to be enabled for board packages (including toolchains).

The hooks need access to some metadata beyond what is available in the temporary build directory: hashes of commits of scripts/coreos-overlay/portage-stable and sdk version currently in use.

## How to use

Together with https://github.com/flatcar-linux/scripts/pull/378, build a full image including toolchains.

## Testing done

http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6068/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
