### PR TITLE
profiles: remove outdated arm64 accept_keywords for curl

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -24,7 +24,6 @@
 =net-firewall/conntrack-tools-1.4.6-r1 ~arm64
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_cttimeout-1.0.0-r1 ~arm64
-=net-misc/curl-7.83.1 ~arm64
 
 =perl-core/File-Path-2.130.0 ~arm64
 =sec-policy/selinux-base-2.20200818-r2 ~arm64


### PR DESCRIPTION
# profiles: remove outdated arm64 accept_keywords for curl

To be merged with https://github.com/flatcar-linux/portage-stable/pull/343

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6065/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
