### PR TITLE
app-editors/vim,vim-core: Add accept_keywords for vim & vim-core

### DIFF
--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -5,5 +5,8 @@ sys-firmware/intel-microcode vanilla
 # Enable gssapi only for amd64, to avoid build errors in arm64.
 net-dns/bind-tools           gssapi
 
-# Disable crypt to avoid installing libsodlium in amd64.
+# -crypt: Disable crypt to avoid installing libsodlium in amd64.
 app-editors/vim		-crypt
+
+# minimal: Don't pull app-vim/gentoo-syntax in amd64
+app-editors/vim-core		minimal

--- a/profiles/coreos/arm64/generic/package.use
+++ b/profiles/coreos/arm64/generic/package.use
@@ -1,2 +1,5 @@
 # Disable crypt to avoid installing libsodlium in arm64.
 app-editors/vim		-crypt
+
+# minimal: Don't pull app-vim/gentoo-syntax in arm64
+app-editors/vim-core		minimal

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -49,8 +49,8 @@
 =sys-apps/iproute2-5.15.0 ~amd64 ~arm64
 
 # Required for some CVEs
-=app-editors/vim-8.2.4328 ~amd64 ~arm64
-=app-editors/vim-core-8.2.4328 ~amd64 ~arm64
+=app-editors/vim-8.2.5066-r1 ~amd64 ~arm64
+=app-editors/vim-core-8.2.5066-r1 ~amd64 ~arm64
 =sys-libs/zlib-1.2.12-r2 ~amd64 ~arm64
 
 # Duktape is not yet stable

--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -38,6 +38,7 @@ INSTALL_MASK="${INSTALL_MASK}
   /etc/sudoers
   /etc/wgetrc
   /etc/xinetd.d
+  /etc/vim/vimrc
 "
 
 # Remove selinuxenabled because it triggers breakage in Ansible


### PR DESCRIPTION
# app-editors/vim,vim-core: Add accept_keywords for vim & vim-core

To be merged with https://github.com/flatcar-linux/portage-stable/pull/344

## Testing done

~Jenkins CI running: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6101/cldsv/~

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
