### PR TITLE
profiles: enable symlink for nmap

### DIFF
--- a/changelog/changes/2022-07-19-ncat.md
+++ b/changelog/changes/2022-07-19-ncat.md
@@ -1,0 +1,1 @@
+- Added symlink from `nc` to `ncat`. `-q` option is [not yet supported](https://github.com/nmap/nmap/issues/2422) ([flatcar#545](https://github.com/flatcar-linux/Flatcar/issues/545))

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -23,7 +23,8 @@ sys-libs/gdbm berkdb
 
 dev-vcs/git -perl -iconv
 
-net-analyzer/nmap ncat -system-lua
+# symlink: to add a link between ncat and nc
+net-analyzer/nmap ncat -system-lua symlink
 
 # removes mta dependencies
 app-admin/sudo -sendmail


### PR DESCRIPTION
For compatiblity, it's good to have `nc` in the PATH too.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

See: https://github.com/flatcar-linux/portage-stable/pull/345
