### PR TITLE
sys-apps/systemd: fix tmpfile entry for resolv.conf link

### DIFF
--- a/changelog/bugfixes/2022-07-26-restore-resolv-conf.md
+++ b/changelog/bugfixes/2022-07-26-restore-resolv-conf.md
@@ -1,0 +1,1 @@
+- Fixed `/etc/resolv.conf` symlink by pointing it at `resolv.conf` instead of `stub-resolv.conf`. This bug was present since the update to systemd v250 ([coreos-overlay#2057](https://github.com/flatcar-linux/coreos-overlay/pull/2057))

--- a/sys-apps/systemd/systemd-250.3-r1.ebuild
+++ b/sys-apps/systemd/systemd-250.3-r1.ebuild
@@ -1,0 +1,1 @@
+systemd-250.3.ebuild

--- a/sys-apps/systemd/systemd-250.3.ebuild
+++ b/sys-apps/systemd/systemd-250.3.ebuild
@@ -272,7 +272,7 @@ src_prepare() {
 	# /run/systemd/resolve/stub-resolv.conf (and if using K8s
 	# configure the kubelet resolvConf variable/--resolv-conf flag
 	# to /run/systemd/resolve/resolv.conf).
-	sed -i -e 's,/run/systemd/resolve/stub-resolv.conf,/run/systemd/resolve/resolv.conf,' tmpfiles.d/etc.conf.in || die
+	sed -i -e 's,/run/systemd/resolve/stub-resolv.conf,/run/systemd/resolve/resolv.conf,' tmpfiles.d/systemd-resolve.conf || die
 
 	default
 }


### PR DESCRIPTION
# sys-apps/systemd: fix tmpfile entry for resolv.conf link

Our ebuild modifies the systemd owned tmpfiles.d entry that creates the
/etc/resolv.conf symlink to point to resolv.conf instead of stub-resolv.conf.
The file that contains that entry changed from etc.conf.in to
systemd-resolve.conf, so update the ebuild to touch that file.


## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

Added new kola test: https://github.com/flatcar-linux/mantle/pull/346 which fails on main and succeeds on this branch.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
