### PR TITLE
coreos-base/init: keep static network configuration

### DIFF
--- a/changelog/bugfixes/2022-07-27-networkd.md
+++ b/changelog/bugfixes/2022-07-27-networkd.md
@@ -1,0 +1,1 @@
+- Excluded Wireguard interface from `systemd-networkd` default management ([Flatcar#808](https://github.com/flatcar-linux/Flatcar/issues/808))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="b99ff0626f5983af7aee47e95f34991d42f68e5b" # flatcar-master
+	CROS_WORKON_COMMIT="8bd753fe41252254a3b3d46829988c4c73ee1a0b" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
this pulls: https://github.com/flatcar-linux/init/pull/77

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6197/cldsv/
- Closes: https://github.com/flatcar-linux/Flatcar/issues/808