### PR TITLE
coreos-base/hard-host-depends: add syft

### DIFF
--- a/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
+++ b/coreos-base/hard-host-depends/hard-host-depends-0.0.1.ebuild
@@ -85,6 +85,7 @@ RDEPEND="${RDEPEND}
 # Useful utilities for developers.
 RDEPEND="${RDEPEND}
 	app-arch/zip
+	app-containers/syft
 	app-doc/eclass-manpages
 	app-portage/gentoolkit
 	app-portage/portage-utils


### PR DESCRIPTION
Otherwise it's not pulled in the SDK

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

CI running (with SDK): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6188/cldsv/
