### PR TITLE
coreos-base/coreos-init: bump commit ID

### DIFF
--- a/changelog/bugfixes/2022-08-03-cloudinit.md
+++ b/changelog/bugfixes/2022-08-03-cloudinit.md
@@ -1,0 +1,1 @@
+- Added support for Openstack for cloud-init activation ([flatcar-linux/init#76](https://github.com/flatcar-linux/init/pull/76))

--- a/changelog/bugfixes/2022-08-03-systemd-networkd.md
+++ b/changelog/bugfixes/2022-08-03-systemd-networkd.md
@@ -1,0 +1,1 @@
+- Fixed excluded interface type from default systemd-networkd configuration ([flatcar-linux/init#78](https://github.com/flatcar-linux/init/pull/78))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="8bd753fe41252254a3b3d46829988c4c73ee1a0b" # flatcar-master
+	CROS_WORKON_COMMIT="2e0b31dc3aed008550489151143e761d4ebeead0" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

This pulls:
* https://github.com/flatcar-linux/init/pull/78
* https://github.com/flatcar-linux/init/pull/76

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6236/