### PR TITLE
sys-kernel/coreos-sources: Regenerate patches

### DIFF
--- a/sys-kernel/coreos-sources/coreos-sources-5.15.58.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-5.15.58.ebuild
@@ -40,4 +40,6 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0003-PCI-hv-Make-the-code-arch-neutral-by-adding-arch-spe.patch \
 	${PATCH_DIR}/z0004-PCI-hv-Add-arm64-Hyper-V-vPCI-support.patch \
 	${PATCH_DIR}/z0005-Drivers-hv-vmbus-Propagate-VMbus-coherence-to-each-V.patch \
+	${PATCH_DIR}/z0006-PCI-hv-Avoid-the-retarget-interrupt-hypercall-in-irq.patch \
+	${PATCH_DIR}/z0007-PCI-hv-Remove-unused-hv_set_msi_entry_from_desc.patch \
 "

--- a/sys-kernel/coreos-sources/files/5.15/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch
@@ -1,7 +1,7 @@
-From 2a4e8c743f97578d3db28c8f0446d8f99e0da3fd Mon Sep 17 00:00:00 2001
+From d51a152409430036e6d939cec2ef73f4fd68bd75 Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
-Subject: [PATCH 1/2] kbuild: derive relative path for srctree from CURDIR
+Subject: [PATCH 1/5] kbuild: derive relative path for srctree from CURDIR
 
 This enables relocating source and build trees to different roots,
 provided they stay reachable relative to one another.  Useful for
@@ -12,10 +12,10 @@ by some undesirable path component.
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index d600b38144f4..846089783807 100644
+index d7ba0de250cb..4da8ba21cab8 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -239,8 +239,10 @@ else
+@@ -243,8 +243,10 @@ else
  	building_out_of_srctree := 1
  endif
  
@@ -29,5 +29,5 @@ index d600b38144f4..846089783807 100644
  
  objtree		:= .
 -- 
-2.26.2
+2.25.1
 

--- a/sys-kernel/coreos-sources/files/5.15/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0001-kbuild-derive-relative-path-for-srctree-from-CURDIR.patch
@@ -1,7 +1,7 @@
-From d51a152409430036e6d939cec2ef73f4fd68bd75 Mon Sep 17 00:00:00 2001
+From 5ae7cedb969c1a392e29653e7a1275ee5ffa9e50 Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
-Subject: [PATCH 1/5] kbuild: derive relative path for srctree from CURDIR
+Subject: [PATCH 1/7] kbuild: derive relative path for srctree from CURDIR
 
 This enables relocating source and build trees to different roots,
 provided they stay reachable relative to one another.  Useful for

--- a/sys-kernel/coreos-sources/files/5.15/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
@@ -1,7 +1,7 @@
-From bb5ea0a6a4a0b7a1a361c8c5dea29628c8e01135 Mon Sep 17 00:00:00 2001
+From 17f850fda11ee63a18bb9b16e4760bbfc33b3020 Mon Sep 17 00:00:00 2001
 From: David Michael <david.michael@coreos.com>
 Date: Thu, 8 Feb 2018 21:23:12 -0500
-Subject: [PATCH 2/2] tools/objtool/Makefile: Don't fail on fallthrough with
+Subject: [PATCH 2/5] tools/objtool/Makefile: Don't fail on fallthrough with
  new GCCs
 
 ---
@@ -23,5 +23,5 @@ index 1c777a72bb39..0217b7af786a 100644
  
  CFLAGS += -I$(srctree)/tools/include/
 -- 
-2.26.2
+2.25.1
 

--- a/sys-kernel/coreos-sources/files/5.15/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
@@ -1,7 +1,7 @@
-From 17f850fda11ee63a18bb9b16e4760bbfc33b3020 Mon Sep 17 00:00:00 2001
+From f654ed34d7082cad0b0105b8f54fc9d78b982eef Mon Sep 17 00:00:00 2001
 From: David Michael <david.michael@coreos.com>
 Date: Thu, 8 Feb 2018 21:23:12 -0500
-Subject: [PATCH 2/5] tools/objtool/Makefile: Don't fail on fallthrough with
+Subject: [PATCH 2/7] tools/objtool/Makefile: Don't fail on fallthrough with
  new GCCs
 
 ---

--- a/sys-kernel/coreos-sources/files/5.15/z0003-PCI-hv-Make-the-code-arch-neutral-by-adding-arch-spe.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0003-PCI-hv-Make-the-code-arch-neutral-by-adding-arch-spe.patch
@@ -1,7 +1,7 @@
-From 41b844d9f633b26dea32242217fdaabc8d11a645 Mon Sep 17 00:00:00 2001
+From 80f4d4e5e1042ea78c527d39f44ee16f5a2d3e5a Mon Sep 17 00:00:00 2001
 From: Sunil Muthuswamy <sunilmut@microsoft.com>
 Date: Wed, 5 Jan 2022 11:32:35 -0800
-Subject: [PATCH 3/5] PCI: hv: Make the code arch neutral by adding arch
+Subject: [PATCH 3/7] PCI: hv: Make the code arch neutral by adding arch
  specific interfaces
 
 Encapsulate arch dependencies in Hyper-V vPCI through a set of
@@ -25,10 +25,10 @@ Reviewed-by: Boqun Feng <boqun.feng@gmail.com>
 Reviewed-by: Marc Zyngier <maz@kernel.org>
 Reviewed-by: Michael Kelley <mikelley@microsoft.com>
 ---
- arch/x86/include/asm/hyperv-tlfs.h  |  33 +++++++++
- drivers/pci/controller/pci-hyperv.c | 101 ++++++++++++++++------------
- include/asm-generic/hyperv-tlfs.h   |  33 ---------
- 3 files changed, 92 insertions(+), 75 deletions(-)
+ arch/x86/include/asm/hyperv-tlfs.h  | 33 ++++++++++
+ drivers/pci/controller/pci-hyperv.c | 94 ++++++++++++++++-------------
+ include/asm-generic/hyperv-tlfs.h   | 33 ----------
+ 3 files changed, 85 insertions(+), 75 deletions(-)
 
 diff --git a/arch/x86/include/asm/hyperv-tlfs.h b/arch/x86/include/asm/hyperv-tlfs.h
 index 2322d6bd5883..fdf3d28fbdd5 100644
@@ -75,7 +75,7 @@ index 2322d6bd5883..fdf3d28fbdd5 100644
  
  #endif
 diff --git a/drivers/pci/controller/pci-hyperv.c b/drivers/pci/controller/pci-hyperv.c
-index 9b54715a4b63..dbbe8417e35e 100644
+index 9b54715a4b63..601d06fe1adc 100644
 --- a/drivers/pci/controller/pci-hyperv.c
 +++ b/drivers/pci/controller/pci-hyperv.c
 @@ -43,9 +43,6 @@
@@ -88,7 +88,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  #include <linux/irq.h>
  #include <linux/msi.h>
  #include <linux/hyperv.h>
-@@ -583,6 +580,51 @@ struct hv_pci_compl {
+@@ -583,6 +580,44 @@ struct hv_pci_compl {
  
  static void hv_pci_onchannelcallback(void *context);
  
@@ -114,13 +114,6 @@ index 9b54715a4b63..dbbe8417e35e 100644
 +	return cfg->vector;
 +}
 +
-+static void hv_set_msi_entry_from_desc(union hv_msi_entry *msi_entry,
-+				       struct msi_desc *msi_desc)
-+{
-+	msi_entry->address.as_uint32 = msi_desc->msg.address_lo;
-+	msi_entry->data.as_uint32 = msi_desc->msg.data;
-+}
-+
 +static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
 +			  int nvec, msi_alloc_info_t *info)
 +{
@@ -140,7 +133,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  /**
   * hv_pci_generic_compl() - Invoked for a completion packet
   * @context:		Set up by the sender of the packet.
-@@ -1195,41 +1237,11 @@ static void hv_msi_free(struct irq_domain *domain, struct msi_domain_info *info,
+@@ -1195,41 +1230,11 @@ static void hv_msi_free(struct irq_domain *domain, struct msi_domain_info *info,
  	put_pcichild(hpdev);
  }
  
@@ -182,7 +175,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  /**
   * hv_irq_unmask() - "Unmask" the IRQ by setting its current
   * affinity.
-@@ -1243,7 +1255,6 @@ static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
+@@ -1243,7 +1248,6 @@ static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
  static void hv_irq_unmask(struct irq_data *data)
  {
  	struct msi_desc *msi_desc = irq_data_get_msi_desc(data);
@@ -190,7 +183,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  	struct hv_retarget_device_interrupt *params;
  	struct tran_int_desc *int_desc;
  	struct hv_pcibus_device *hbus;
-@@ -1275,7 +1286,7 @@ static void hv_irq_unmask(struct irq_data *data)
+@@ -1275,7 +1279,7 @@ static void hv_irq_unmask(struct irq_data *data)
  			   (hbus->hdev->dev_instance.b[7] << 8) |
  			   (hbus->hdev->dev_instance.b[6] & 0xf8) |
  			   PCI_FUNC(pdev->devfn);
@@ -199,7 +192,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  
  	/*
  	 * Honoring apic->delivery_mode set to APIC_DELIVERY_MODE_FIXED by
-@@ -1376,7 +1387,7 @@ static u32 hv_compose_msi_req_v1(
+@@ -1376,7 +1380,7 @@ static u32 hv_compose_msi_req_v1(
  	int_pkt->wslot.slot = slot;
  	int_pkt->int_desc.vector = vector;
  	int_pkt->int_desc.vector_count = vector_count;
@@ -208,7 +201,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  
  	/*
  	 * Create MSI w/ dummy vCPU set, overwritten by subsequent retarget in
-@@ -1406,7 +1417,7 @@ static u32 hv_compose_msi_req_v2(
+@@ -1406,7 +1410,7 @@ static u32 hv_compose_msi_req_v2(
  	int_pkt->wslot.slot = slot;
  	int_pkt->int_desc.vector = vector;
  	int_pkt->int_desc.vector_count = vector_count;
@@ -217,7 +210,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  	cpu = hv_compose_msi_req_get_cpu(affinity);
  	int_pkt->int_desc.processor_array[0] =
  		hv_cpu_number_to_vp_number(cpu);
-@@ -1426,7 +1437,7 @@ static u32 hv_compose_msi_req_v3(
+@@ -1426,7 +1430,7 @@ static u32 hv_compose_msi_req_v3(
  	int_pkt->int_desc.vector = vector;
  	int_pkt->int_desc.reserved = 0;
  	int_pkt->int_desc.vector_count = vector_count;
@@ -226,7 +219,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  	cpu = hv_compose_msi_req_get_cpu(affinity);
  	int_pkt->int_desc.processor_array[0] =
  		hv_cpu_number_to_vp_number(cpu);
-@@ -1660,7 +1671,7 @@ static void hv_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
+@@ -1660,7 +1664,7 @@ static void hv_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
  static struct irq_chip hv_msi_irq_chip = {
  	.name			= "Hyper-V PCIe MSI",
  	.irq_compose_msi_msg	= hv_compose_msi_msg,
@@ -235,7 +228,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  	.irq_ack		= irq_chip_ack_parent,
  	.irq_mask		= hv_irq_mask,
  	.irq_unmask		= hv_irq_unmask,
-@@ -1691,12 +1702,12 @@ static int hv_pcie_init_irq_domain(struct hv_pcibus_device *hbus)
+@@ -1691,12 +1695,12 @@ static int hv_pcie_init_irq_domain(struct hv_pcibus_device *hbus)
  	hbus->msi_info.flags = (MSI_FLAG_USE_DEF_DOM_OPS |
  		MSI_FLAG_USE_DEF_CHIP_OPS | MSI_FLAG_MULTI_PCI_MSI |
  		MSI_FLAG_PCI_MSIX);
@@ -251,7 +244,7 @@ index 9b54715a4b63..dbbe8417e35e 100644
  	if (!hbus->irq_domain) {
  		dev_err(&hbus->hdev->device,
  			"Failed to build an MSI IRQ domain\n");
-@@ -3626,9 +3637,15 @@ static void __exit exit_hv_pci_drv(void)
+@@ -3626,9 +3630,15 @@ static void __exit exit_hv_pci_drv(void)
  
  static int __init init_hv_pci_drv(void)
  {

--- a/sys-kernel/coreos-sources/files/5.15/z0003-PCI-hv-Make-the-code-arch-neutral-by-adding-arch-spe.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0003-PCI-hv-Make-the-code-arch-neutral-by-adding-arch-spe.patch
@@ -1,7 +1,7 @@
-From 831c1ae725f7d2f8f858b0840692b48e75b49331 Mon Sep 17 00:00:00 2001
+From 41b844d9f633b26dea32242217fdaabc8d11a645 Mon Sep 17 00:00:00 2001
 From: Sunil Muthuswamy <sunilmut@microsoft.com>
 Date: Wed, 5 Jan 2022 11:32:35 -0800
-Subject: [PATCH 1/2] PCI: hv: Make the code arch neutral by adding arch
+Subject: [PATCH 3/5] PCI: hv: Make the code arch neutral by adding arch
  specific interfaces
 
 Encapsulate arch dependencies in Hyper-V vPCI through a set of
@@ -9,6 +9,13 @@ arch-dependent interfaces. Adding these arch specific interfaces will
 allow for an implementation for other architectures, such as arm64.
 
 There are no functional changes expected from this patch.
+
+krnowak: Backport to 5.15 - this patch adds the hv_msi_get_int_vector
+function for x64, so drop the same function that was brought in by
+another patch backported to 5.15 from master. Similar thing goes for
+the hv_msi_prepare function, but this time the function brought under
+the CONFIG_X86 is amended to match the fixed variant that was already
+a part of 5.15.
 
 Link: https://lore.kernel.org/r/1641411156-31705-2-git-send-email-sunilmut@linux.microsoft.com
 Signed-off-by: Sunil Muthuswamy <sunilmut@microsoft.com>
@@ -18,17 +25,16 @@ Reviewed-by: Boqun Feng <boqun.feng@gmail.com>
 Reviewed-by: Marc Zyngier <maz@kernel.org>
 Reviewed-by: Michael Kelley <mikelley@microsoft.com>
 ---
- arch/x86/include/asm/hyperv-tlfs.h  | 33 ++++++++++++
- arch/x86/include/asm/mshyperv.h     |  7 ---
- drivers/pci/controller/pci-hyperv.c | 79 ++++++++++++++++++++---------
- include/asm-generic/hyperv-tlfs.h   | 33 ------------
- 4 files changed, 87 insertions(+), 65 deletions(-)
+ arch/x86/include/asm/hyperv-tlfs.h  |  33 +++++++++
+ drivers/pci/controller/pci-hyperv.c | 101 ++++++++++++++++------------
+ include/asm-generic/hyperv-tlfs.h   |  33 ---------
+ 3 files changed, 92 insertions(+), 75 deletions(-)
 
 diff --git a/arch/x86/include/asm/hyperv-tlfs.h b/arch/x86/include/asm/hyperv-tlfs.h
-index 381e88122a5f..0a9407dc0859 100644
+index 2322d6bd5883..fdf3d28fbdd5 100644
 --- a/arch/x86/include/asm/hyperv-tlfs.h
 +++ b/arch/x86/include/asm/hyperv-tlfs.h
-@@ -602,6 +602,39 @@ enum hv_interrupt_type {
+@@ -585,6 +585,39 @@ enum hv_interrupt_type {
  	HV_X64_INTERRUPT_TYPE_MAXIMUM           = 0x000A,
  };
  
@@ -68,26 +74,8 @@ index 381e88122a5f..0a9407dc0859 100644
  #include <asm-generic/hyperv-tlfs.h>
  
  #endif
-diff --git a/arch/x86/include/asm/mshyperv.h b/arch/x86/include/asm/mshyperv.h
-index da3972fe5a7a..a1c3dceff8eb 100644
---- a/arch/x86/include/asm/mshyperv.h
-+++ b/arch/x86/include/asm/mshyperv.h
-@@ -169,13 +169,6 @@ bool hv_vcpu_is_preempted(int vcpu);
- static inline void hv_apic_init(void) {}
- #endif
- 
--static inline void hv_set_msi_entry_from_desc(union hv_msi_entry *msi_entry,
--					      struct msi_desc *msi_desc)
--{
--	msi_entry->address.as_uint32 = msi_desc->msg.address_lo;
--	msi_entry->data.as_uint32 = msi_desc->msg.data;
--}
--
- struct irq_domain *hv_create_pci_msi_domain(void);
- 
- int hv_map_ioapic_interrupt(int ioapic_id, bool level, int vcpu, int vector,
 diff --git a/drivers/pci/controller/pci-hyperv.c b/drivers/pci/controller/pci-hyperv.c
-index 6733cb14e775..ead7d6cb6bf1 100644
+index 9b54715a4b63..dbbe8417e35e 100644
 --- a/drivers/pci/controller/pci-hyperv.c
 +++ b/drivers/pci/controller/pci-hyperv.c
 @@ -43,9 +43,6 @@
@@ -100,7 +88,7 @@ index 6733cb14e775..ead7d6cb6bf1 100644
  #include <linux/irq.h>
  #include <linux/msi.h>
  #include <linux/hyperv.h>
-@@ -583,6 +580,42 @@ struct hv_pci_compl {
+@@ -583,6 +580,51 @@ struct hv_pci_compl {
  
  static void hv_pci_onchannelcallback(void *context);
  
@@ -136,14 +124,23 @@ index 6733cb14e775..ead7d6cb6bf1 100644
 +static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
 +			  int nvec, msi_alloc_info_t *info)
 +{
-+	return pci_msi_prepare(domain, dev, nvec, info);
++	int ret = pci_msi_prepare(domain, dev, nvec, info);
++
++	/*
++	 * By using the interrupt remapper in the hypervisor IOMMU, contiguous
++	 * CPU vectors is not needed for multi-MSI
++	 */
++	if (info->type == X86_IRQ_ALLOC_TYPE_PCI_MSI)
++		info->flags &= ~X86_IRQ_ALLOC_CONTIGUOUS_VECTORS;
++
++	return ret;
 +}
 +#endif /* CONFIG_X86 */
 +
  /**
   * hv_pci_generic_compl() - Invoked for a completion packet
   * @context:		Set up by the sender of the packet.
-@@ -1191,14 +1224,6 @@ static void hv_msi_free(struct irq_domain *domain, struct msi_domain_info *info,
+@@ -1195,41 +1237,11 @@ static void hv_msi_free(struct irq_domain *domain, struct msi_domain_info *info,
  	put_pcichild(hpdev);
  }
  
@@ -158,15 +155,42 @@ index 6733cb14e775..ead7d6cb6bf1 100644
  static void hv_irq_mask(struct irq_data *data)
  {
  	pci_msi_mask_irq(data);
-@@ -1217,7 +1242,6 @@ static void hv_irq_mask(struct irq_data *data)
+ }
+ 
+-static unsigned int hv_msi_get_int_vector(struct irq_data *data)
+-{
+-	struct irq_cfg *cfg = irqd_cfg(data);
+-
+-	return cfg->vector;
+-}
+-
+-static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
+-			  int nvec, msi_alloc_info_t *info)
+-{
+-	int ret = pci_msi_prepare(domain, dev, nvec, info);
+-
+-	/*
+-	 * By using the interrupt remapper in the hypervisor IOMMU, contiguous
+-	 * CPU vectors is not needed for multi-MSI
+-	 */
+-	if (info->type == X86_IRQ_ALLOC_TYPE_PCI_MSI)
+-		info->flags &= ~X86_IRQ_ALLOC_CONTIGUOUS_VECTORS;
+-
+-	return ret;
+-}
+-
+ /**
+  * hv_irq_unmask() - "Unmask" the IRQ by setting its current
+  * affinity.
+@@ -1243,7 +1255,6 @@ static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
  static void hv_irq_unmask(struct irq_data *data)
  {
  	struct msi_desc *msi_desc = irq_data_get_msi_desc(data);
 -	struct irq_cfg *cfg = irqd_cfg(data);
  	struct hv_retarget_device_interrupt *params;
+ 	struct tran_int_desc *int_desc;
  	struct hv_pcibus_device *hbus;
- 	struct cpumask *dest;
-@@ -1246,7 +1270,7 @@ static void hv_irq_unmask(struct irq_data *data)
+@@ -1275,7 +1286,7 @@ static void hv_irq_unmask(struct irq_data *data)
  			   (hbus->hdev->dev_instance.b[7] << 8) |
  			   (hbus->hdev->dev_instance.b[6] & 0xf8) |
  			   PCI_FUNC(pdev->devfn);
@@ -175,68 +199,34 @@ index 6733cb14e775..ead7d6cb6bf1 100644
  
  	/*
  	 * Honoring apic->delivery_mode set to APIC_DELIVERY_MODE_FIXED by
-@@ -1347,7 +1371,7 @@ static u32 hv_compose_msi_req_v1(
+@@ -1376,7 +1387,7 @@ static u32 hv_compose_msi_req_v1(
  	int_pkt->wslot.slot = slot;
  	int_pkt->int_desc.vector = vector;
- 	int_pkt->int_desc.vector_count = 1;
+ 	int_pkt->int_desc.vector_count = vector_count;
 -	int_pkt->int_desc.delivery_mode = APIC_DELIVERY_MODE_FIXED;
 +	int_pkt->int_desc.delivery_mode = DELIVERY_MODE;
  
  	/*
  	 * Create MSI w/ dummy vCPU set, overwritten by subsequent retarget in
-@@ -1377,7 +1401,7 @@ static u32 hv_compose_msi_req_v2(
+@@ -1406,7 +1417,7 @@ static u32 hv_compose_msi_req_v2(
  	int_pkt->wslot.slot = slot;
  	int_pkt->int_desc.vector = vector;
- 	int_pkt->int_desc.vector_count = 1;
+ 	int_pkt->int_desc.vector_count = vector_count;
 -	int_pkt->int_desc.delivery_mode = APIC_DELIVERY_MODE_FIXED;
 +	int_pkt->int_desc.delivery_mode = DELIVERY_MODE;
  	cpu = hv_compose_msi_req_get_cpu(affinity);
  	int_pkt->int_desc.processor_array[0] =
  		hv_cpu_number_to_vp_number(cpu);
-@@ -1397,7 +1421,7 @@ static u32 hv_compose_msi_req_v3(
+@@ -1426,7 +1437,7 @@ static u32 hv_compose_msi_req_v3(
  	int_pkt->int_desc.vector = vector;
  	int_pkt->int_desc.reserved = 0;
- 	int_pkt->int_desc.vector_count = 1;
+ 	int_pkt->int_desc.vector_count = vector_count;
 -	int_pkt->int_desc.delivery_mode = APIC_DELIVERY_MODE_FIXED;
 +	int_pkt->int_desc.delivery_mode = DELIVERY_MODE;
  	cpu = hv_compose_msi_req_get_cpu(affinity);
  	int_pkt->int_desc.processor_array[0] =
  		hv_cpu_number_to_vp_number(cpu);
-@@ -1419,7 +1443,6 @@ static u32 hv_compose_msi_req_v3(
-  */
- static void hv_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
- {
--	struct irq_cfg *cfg = irqd_cfg(data);
- 	struct hv_pcibus_device *hbus;
- 	struct vmbus_channel *channel;
- 	struct hv_pci_dev *hpdev;
-@@ -1470,7 +1493,7 @@ static void hv_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
- 		size = hv_compose_msi_req_v1(&ctxt.int_pkts.v1,
- 					dest,
- 					hpdev->desc.win_slot.slot,
--					cfg->vector);
-+					hv_msi_get_int_vector(data));
- 		break;
- 
- 	case PCI_PROTOCOL_VERSION_1_2:
-@@ -1478,14 +1501,14 @@ static void hv_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
- 		size = hv_compose_msi_req_v2(&ctxt.int_pkts.v2,
- 					dest,
- 					hpdev->desc.win_slot.slot,
--					cfg->vector);
-+					hv_msi_get_int_vector(data));
- 		break;
- 
- 	case PCI_PROTOCOL_VERSION_1_4:
- 		size = hv_compose_msi_req_v3(&ctxt.int_pkts.v3,
- 					dest,
- 					hpdev->desc.win_slot.slot,
--					cfg->vector);
-+					hv_msi_get_int_vector(data));
- 		break;
- 
- 	default:
-@@ -1594,14 +1617,14 @@ static void hv_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
+@@ -1660,7 +1671,7 @@ static void hv_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
  static struct irq_chip hv_msi_irq_chip = {
  	.name			= "Hyper-V PCIe MSI",
  	.irq_compose_msi_msg	= hv_compose_msi_msg,
@@ -245,15 +235,7 @@ index 6733cb14e775..ead7d6cb6bf1 100644
  	.irq_ack		= irq_chip_ack_parent,
  	.irq_mask		= hv_irq_mask,
  	.irq_unmask		= hv_irq_unmask,
- };
- 
- static struct msi_domain_ops hv_msi_ops = {
--	.msi_prepare	= pci_msi_prepare,
-+	.msi_prepare	= hv_msi_prepare,
- 	.msi_free	= hv_msi_free,
- };
- 
-@@ -1625,12 +1648,12 @@ static int hv_pcie_init_irq_domain(struct hv_pcibus_device *hbus)
+@@ -1691,12 +1702,12 @@ static int hv_pcie_init_irq_domain(struct hv_pcibus_device *hbus)
  	hbus->msi_info.flags = (MSI_FLAG_USE_DEF_DOM_OPS |
  		MSI_FLAG_USE_DEF_CHIP_OPS | MSI_FLAG_MULTI_PCI_MSI |
  		MSI_FLAG_PCI_MSIX);
@@ -269,7 +251,7 @@ index 6733cb14e775..ead7d6cb6bf1 100644
  	if (!hbus->irq_domain) {
  		dev_err(&hbus->hdev->device,
  			"Failed to build an MSI IRQ domain\n");
-@@ -3542,9 +3565,15 @@ static void __exit exit_hv_pci_drv(void)
+@@ -3626,9 +3637,15 @@ static void __exit exit_hv_pci_drv(void)
  
  static int __init init_hv_pci_drv(void)
  {
@@ -286,10 +268,10 @@ index 6733cb14e775..ead7d6cb6bf1 100644
  	set_bit(HVPCI_DOM_INVALID, hvpci_dom_map);
  
 diff --git a/include/asm-generic/hyperv-tlfs.h b/include/asm-generic/hyperv-tlfs.h
-index 8ed6733d5146..8f97c2927bee 100644
+index 56348a541c50..45cc0c3b8ed7 100644
 --- a/include/asm-generic/hyperv-tlfs.h
 +++ b/include/asm-generic/hyperv-tlfs.h
-@@ -540,39 +540,6 @@ enum hv_interrupt_source {
+@@ -539,39 +539,6 @@ enum hv_interrupt_source {
  	HV_INTERRUPT_SOURCE_IOAPIC,
  };
  
@@ -330,5 +312,5 @@ index 8ed6733d5146..8f97c2927bee 100644
  	u64 as_uint64;
  
 -- 
-2.32.0
+2.25.1
 

--- a/sys-kernel/coreos-sources/files/5.15/z0004-PCI-hv-Add-arm64-Hyper-V-vPCI-support.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0004-PCI-hv-Add-arm64-Hyper-V-vPCI-support.patch
@@ -1,7 +1,7 @@
-From d9932b46915664c88709d59927fa67e797adec56 Mon Sep 17 00:00:00 2001
+From 3f4698886b7c3bcc95de4aea5c852d4e5ab59544 Mon Sep 17 00:00:00 2001
 From: Sunil Muthuswamy <sunilmut@microsoft.com>
 Date: Wed, 5 Jan 2022 11:32:36 -0800
-Subject: [PATCH 2/2] PCI: hv: Add arm64 Hyper-V vPCI support
+Subject: [PATCH 4/5] PCI: hv: Add arm64 Hyper-V vPCI support
 
 Add arm64 Hyper-V vPCI support by implementing the arch specific
 interfaces. Introduce an IRQ domain and chip specific to Hyper-v vPCI that
@@ -57,10 +57,10 @@ index 43e615aa12ff..d98fafdd0f99 100644
  	help
  	  The PCI device frontend driver allows the kernel to import arbitrary
 diff --git a/drivers/pci/controller/Kconfig b/drivers/pci/controller/Kconfig
-index 93b141110537..2536abcc045a 100644
+index 326f7d13024f..b24edba0b870 100644
 --- a/drivers/pci/controller/Kconfig
 +++ b/drivers/pci/controller/Kconfig
-@@ -281,7 +281,7 @@ config PCIE_BRCMSTB
+@@ -280,7 +280,7 @@ config PCIE_BRCMSTB
  
  config PCI_HYPERV_INTERFACE
  	tristate "Hyper-V PCI Interface"
@@ -70,7 +70,7 @@ index 93b141110537..2536abcc045a 100644
  	  The Hyper-V PCI Interface is a helper driver allows other drivers to
  	  have a common interface with the Hyper-V PCI frontend driver.
 diff --git a/drivers/pci/controller/pci-hyperv.c b/drivers/pci/controller/pci-hyperv.c
-index ead7d6cb6bf1..31743f93199e 100644
+index dbbe8417e35e..e123cf8a2b3c 100644
 --- a/drivers/pci/controller/pci-hyperv.c
 +++ b/drivers/pci/controller/pci-hyperv.c
 @@ -47,6 +47,8 @@
@@ -82,9 +82,9 @@ index ead7d6cb6bf1..31743f93199e 100644
  #include <asm/mshyperv.h>
  
  /*
-@@ -614,7 +616,230 @@ static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
- {
- 	return pci_msi_prepare(domain, dev, nvec, info);
+@@ -623,7 +625,230 @@ static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
+ 
+ 	return ret;
  }
 -#endif /* CONFIG_X86 */
 +#elif defined(CONFIG_ARM64)
@@ -314,7 +314,7 @@ index ead7d6cb6bf1..31743f93199e 100644
  
  /**
   * hv_pci_generic_compl() - Invoked for a completion packet
-@@ -1227,6 +1452,8 @@ static void hv_msi_free(struct irq_domain *domain, struct msi_domain_info *info,
+@@ -1240,6 +1465,8 @@ static void hv_msi_free(struct irq_domain *domain, struct msi_domain_info *info,
  static void hv_irq_mask(struct irq_data *data)
  {
  	pci_msi_mask_irq(data);
@@ -323,7 +323,7 @@ index ead7d6cb6bf1..31743f93199e 100644
  }
  
  /**
-@@ -1343,6 +1570,8 @@ static void hv_irq_unmask(struct irq_data *data)
+@@ -1359,6 +1586,8 @@ static void hv_irq_unmask(struct irq_data *data)
  		dev_err(&hbus->hdev->device,
  			"%s() failed: %#llx", __func__, res);
  
@@ -332,7 +332,7 @@ index ead7d6cb6bf1..31743f93199e 100644
  	pci_msi_unmask_irq(data);
  }
  
-@@ -1618,7 +1847,11 @@ static struct irq_chip hv_msi_irq_chip = {
+@@ -1672,7 +1901,11 @@ static struct irq_chip hv_msi_irq_chip = {
  	.name			= "Hyper-V PCIe MSI",
  	.irq_compose_msi_msg	= hv_compose_msi_msg,
  	.irq_set_affinity	= irq_chip_set_affinity_parent,
@@ -345,5 +345,5 @@ index ead7d6cb6bf1..31743f93199e 100644
  	.irq_unmask		= hv_irq_unmask,
  };
 -- 
-2.32.0
+2.25.1
 

--- a/sys-kernel/coreos-sources/files/5.15/z0004-PCI-hv-Add-arm64-Hyper-V-vPCI-support.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0004-PCI-hv-Add-arm64-Hyper-V-vPCI-support.patch
@@ -1,7 +1,7 @@
-From 3f4698886b7c3bcc95de4aea5c852d4e5ab59544 Mon Sep 17 00:00:00 2001
+From 802291ee132c756996438afb97dd9d25f9fa5d08 Mon Sep 17 00:00:00 2001
 From: Sunil Muthuswamy <sunilmut@microsoft.com>
 Date: Wed, 5 Jan 2022 11:32:36 -0800
-Subject: [PATCH 4/5] PCI: hv: Add arm64 Hyper-V vPCI support
+Subject: [PATCH 4/7] PCI: hv: Add arm64 Hyper-V vPCI support
 
 Add arm64 Hyper-V vPCI support by implementing the arch specific
 interfaces. Introduce an IRQ domain and chip specific to Hyper-v vPCI that
@@ -70,7 +70,7 @@ index 326f7d13024f..b24edba0b870 100644
  	  The Hyper-V PCI Interface is a helper driver allows other drivers to
  	  have a common interface with the Hyper-V PCI frontend driver.
 diff --git a/drivers/pci/controller/pci-hyperv.c b/drivers/pci/controller/pci-hyperv.c
-index dbbe8417e35e..e123cf8a2b3c 100644
+index 601d06fe1adc..42c625bc5944 100644
 --- a/drivers/pci/controller/pci-hyperv.c
 +++ b/drivers/pci/controller/pci-hyperv.c
 @@ -47,6 +47,8 @@
@@ -82,7 +82,7 @@ index dbbe8417e35e..e123cf8a2b3c 100644
  #include <asm/mshyperv.h>
  
  /*
-@@ -623,7 +625,230 @@ static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
+@@ -616,7 +618,230 @@ static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
  
  	return ret;
  }
@@ -314,7 +314,7 @@ index dbbe8417e35e..e123cf8a2b3c 100644
  
  /**
   * hv_pci_generic_compl() - Invoked for a completion packet
-@@ -1240,6 +1465,8 @@ static void hv_msi_free(struct irq_domain *domain, struct msi_domain_info *info,
+@@ -1233,6 +1458,8 @@ static void hv_msi_free(struct irq_domain *domain, struct msi_domain_info *info,
  static void hv_irq_mask(struct irq_data *data)
  {
  	pci_msi_mask_irq(data);
@@ -323,7 +323,7 @@ index dbbe8417e35e..e123cf8a2b3c 100644
  }
  
  /**
-@@ -1359,6 +1586,8 @@ static void hv_irq_unmask(struct irq_data *data)
+@@ -1352,6 +1579,8 @@ static void hv_irq_unmask(struct irq_data *data)
  		dev_err(&hbus->hdev->device,
  			"%s() failed: %#llx", __func__, res);
  
@@ -332,7 +332,7 @@ index dbbe8417e35e..e123cf8a2b3c 100644
  	pci_msi_unmask_irq(data);
  }
  
-@@ -1672,7 +1901,11 @@ static struct irq_chip hv_msi_irq_chip = {
+@@ -1665,7 +1894,11 @@ static struct irq_chip hv_msi_irq_chip = {
  	.name			= "Hyper-V PCIe MSI",
  	.irq_compose_msi_msg	= hv_compose_msi_msg,
  	.irq_set_affinity	= irq_chip_set_affinity_parent,

--- a/sys-kernel/coreos-sources/files/5.15/z0005-Drivers-hv-vmbus-Propagate-VMbus-coherence-to-each-V.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0005-Drivers-hv-vmbus-Propagate-VMbus-coherence-to-each-V.patch
@@ -1,7 +1,7 @@
-From b1b77cc3614b1f39a270d203c77d79834e9e91f3 Mon Sep 17 00:00:00 2001
+From 75baa46a53a465668cbb875ceef03e659ff29694 Mon Sep 17 00:00:00 2001
 From: Michael Kelley <mikelley@microsoft.com>
 Date: Thu, 24 Mar 2022 09:14:51 -0700
-Subject: [PATCH 1/2] Drivers: hv: vmbus: Propagate VMbus coherence to each
+Subject: [PATCH 5/5] Drivers: hv: vmbus: Propagate VMbus coherence to each
  VMbus device
 
 VMbus synthetic devices are not represented in the ACPI DSDT -- only
@@ -16,8 +16,14 @@ Fix this by propagating coherence information from the VMbus node
 in ACPI to the individual synthetic devices. There's no effect on
 x86/x64 where devices are always hardware coherent.
 
+krnowak: Backport to 5.15 - fixed conflict stemming from hv_map_memory
+and hv_unmap_memory being in diff context. These functions do not
+exist in 5.15.
+
 Signed-off-by: Michael Kelley <mikelley@microsoft.com>
 Acked-by: Robin Murphy <robin.murphy@arm.com>
+Link: https://lore.kernel.org/r/1648138492-2191-2-git-send-email-mikelley@microsoft.com
+Signed-off-by: Wei Liu <wei.liu@kernel.org>
 ---
  drivers/hv/hv_common.c         | 11 +++++++++++
  drivers/hv/vmbus_drv.c         | 31 +++++++++++++++++++++++++++++++
@@ -54,7 +60,7 @@ index c0d9048a4112..196cedd5f37c 100644
  {
  	return !hv_root_partition && acpi_sleep_state_supported(ACPI_STATE_S4);
 diff --git a/drivers/hv/vmbus_drv.c b/drivers/hv/vmbus_drv.c
-index 44bd0b6ff505..fdbd5531405e 100644
+index 50d9113f5402..1f38d0a6548d 100644
 --- a/drivers/hv/vmbus_drv.c
 +++ b/drivers/hv/vmbus_drv.c
 @@ -919,6 +919,21 @@ static int vmbus_probe(struct device *child_device)
@@ -87,7 +93,7 @@ index 44bd0b6ff505..fdbd5531405e 100644
  	.dev_groups =		vmbus_dev_groups,
  	.drv_groups =		vmbus_drv_groups,
  	.bus_groups =		vmbus_bus_groups,
-@@ -2424,6 +2440,21 @@ static int vmbus_acpi_add(struct acpi_device *device)
+@@ -2430,6 +2446,21 @@ static int vmbus_acpi_add(struct acpi_device *device)
  
  	hv_acpi_dev = device;
  
@@ -122,5 +128,5 @@ index d3eae6cdbacb..807f1b524af2 100644
  static inline bool hv_is_hyperv_initialized(void) { return false; }
  static inline bool hv_is_hibernation_supported(void) { return false; }
 -- 
-2.32.0
+2.25.1
 

--- a/sys-kernel/coreos-sources/files/5.15/z0005-Drivers-hv-vmbus-Propagate-VMbus-coherence-to-each-V.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0005-Drivers-hv-vmbus-Propagate-VMbus-coherence-to-each-V.patch
@@ -1,7 +1,7 @@
-From 75baa46a53a465668cbb875ceef03e659ff29694 Mon Sep 17 00:00:00 2001
+From cdbc1cd23ea659b8fc8f67fa0d88654eb90a01fe Mon Sep 17 00:00:00 2001
 From: Michael Kelley <mikelley@microsoft.com>
 Date: Thu, 24 Mar 2022 09:14:51 -0700
-Subject: [PATCH 5/5] Drivers: hv: vmbus: Propagate VMbus coherence to each
+Subject: [PATCH 5/7] Drivers: hv: vmbus: Propagate VMbus coherence to each
  VMbus device
 
 VMbus synthetic devices are not represented in the ACPI DSDT -- only

--- a/sys-kernel/coreos-sources/files/5.15/z0006-PCI-hv-Avoid-the-retarget-interrupt-hypercall-in-irq.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0006-PCI-hv-Avoid-the-retarget-interrupt-hypercall-in-irq.patch
@@ -1,0 +1,302 @@
+From 72b9ec2f281657bd50c8acfc0aa297ccd9a9f260 Mon Sep 17 00:00:00 2001
+From: Boqun Feng <boqun.feng@gmail.com>
+Date: Thu, 17 Feb 2022 11:45:19 +0800
+Subject: [PATCH 6/7] PCI: hv: Avoid the retarget interrupt hypercall in
+ irq_unmask() on ARM64
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On ARM64 Hyper-V guests, SPIs are used for the interrupts of virtual PCI
+devices, and SPIs can be managed directly via GICD registers. Therefore
+the retarget interrupt hypercall is not needed on ARM64.
+
+An arch-specific interface hv_arch_irq_unmask() is introduced to handle
+the architecture level differences on this. For x86, the behavior
+remains unchanged, while for ARM64 no hypercall is invoked when
+unmasking an irq for virtual PCI devices.
+
+Link: https://lore.kernel.org/r/20220217034525.1687678-1-boqun.feng@gmail.com
+Signed-off-by: Boqun Feng <boqun.feng@gmail.com>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Reviewed-by: Michael Kelley <mikelley@microsoft.com>
+
+jepio: Upstream commit d06957d7a6929e6a4aa959cb59d66f0c095fc974+squashed
+455880dfe292a2bdd3b4ad6a107299fce610e64b into this. 5.15 contains 455880d
+(35d24b115a407c0a1a73900d025da77be2763ed3) but not the rest of ARM64+PCI
+enablement (which we carry) so without this patch there is a build failure:
+
+  drivers/pci/controller/pci-hyperv.c:1509:37: error: request for member ���as_uint32��� in something not a structure or union
+---
+ drivers/pci/controller/pci-hyperv.c | 239 +++++++++++++++-------------
+ 1 file changed, 125 insertions(+), 114 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-hyperv.c b/drivers/pci/controller/pci-hyperv.c
+index 42c625bc5944..165dfb98d3d8 100644
+--- a/drivers/pci/controller/pci-hyperv.c
++++ b/drivers/pci/controller/pci-hyperv.c
+@@ -618,6 +618,124 @@ static int hv_msi_prepare(struct irq_domain *domain, struct device *dev,
+ 
+ 	return ret;
+ }
++
++/**
++ * hv_arch_irq_unmask() - "Unmask" the IRQ by setting its current
++ * affinity.
++ * @data:	Describes the IRQ
++ *
++ * Build new a destination for the MSI and make a hypercall to
++ * update the Interrupt Redirection Table. "Device Logical ID"
++ * is built out of this PCI bus's instance GUID and the function
++ * number of the device.
++ */
++static void hv_arch_irq_unmask(struct irq_data *data)
++{
++	struct msi_desc *msi_desc = irq_data_get_msi_desc(data);
++	struct hv_retarget_device_interrupt *params;
++	struct tran_int_desc *int_desc;
++	struct hv_pcibus_device *hbus;
++	struct cpumask *dest;
++	cpumask_var_t tmp;
++	struct pci_bus *pbus;
++	struct pci_dev *pdev;
++	unsigned long flags;
++	u32 var_size = 0;
++	int cpu, nr_bank;
++	u64 res;
++
++	dest = irq_data_get_effective_affinity_mask(data);
++	pdev = msi_desc_to_pci_dev(msi_desc);
++	pbus = pdev->bus;
++	hbus = container_of(pbus->sysdata, struct hv_pcibus_device, sysdata);
++	int_desc = data->chip_data;
++
++	spin_lock_irqsave(&hbus->retarget_msi_interrupt_lock, flags);
++
++	params = &hbus->retarget_msi_interrupt_params;
++	memset(params, 0, sizeof(*params));
++	params->partition_id = HV_PARTITION_ID_SELF;
++	params->int_entry.source = HV_INTERRUPT_SOURCE_MSI;
++	params->int_entry.msi_entry.address.as_uint32 = int_desc->address & 0xffffffff;
++	params->int_entry.msi_entry.data.as_uint32 = int_desc->data;
++	params->device_id = (hbus->hdev->dev_instance.b[5] << 24) |
++			   (hbus->hdev->dev_instance.b[4] << 16) |
++			   (hbus->hdev->dev_instance.b[7] << 8) |
++			   (hbus->hdev->dev_instance.b[6] & 0xf8) |
++			   PCI_FUNC(pdev->devfn);
++	params->int_target.vector = hv_msi_get_int_vector(data);
++
++	/*
++	 * Honoring apic->delivery_mode set to APIC_DELIVERY_MODE_FIXED by
++	 * setting the HV_DEVICE_INTERRUPT_TARGET_MULTICAST flag results in a
++	 * spurious interrupt storm. Not doing so does not seem to have a
++	 * negative effect (yet?).
++	 */
++
++	if (hbus->protocol_version >= PCI_PROTOCOL_VERSION_1_2) {
++		/*
++		 * PCI_PROTOCOL_VERSION_1_2 supports the VP_SET version of the
++		 * HVCALL_RETARGET_INTERRUPT hypercall, which also coincides
++		 * with >64 VP support.
++		 * ms_hyperv.hints & HV_X64_EX_PROCESSOR_MASKS_RECOMMENDED
++		 * is not sufficient for this hypercall.
++		 */
++		params->int_target.flags |=
++			HV_DEVICE_INTERRUPT_TARGET_PROCESSOR_SET;
++
++		if (!alloc_cpumask_var(&tmp, GFP_ATOMIC)) {
++			res = 1;
++			goto exit_unlock;
++		}
++
++		cpumask_and(tmp, dest, cpu_online_mask);
++		nr_bank = cpumask_to_vpset(&params->int_target.vp_set, tmp);
++		free_cpumask_var(tmp);
++
++		if (nr_bank <= 0) {
++			res = 1;
++			goto exit_unlock;
++		}
++
++		/*
++		 * var-sized hypercall, var-size starts after vp_mask (thus
++		 * vp_set.format does not count, but vp_set.valid_bank_mask
++		 * does).
++		 */
++		var_size = 1 + nr_bank;
++	} else {
++		for_each_cpu_and(cpu, dest, cpu_online_mask) {
++			params->int_target.vp_mask |=
++				(1ULL << hv_cpu_number_to_vp_number(cpu));
++		}
++	}
++
++	res = hv_do_hypercall(HVCALL_RETARGET_INTERRUPT | (var_size << 17),
++			      params, NULL);
++
++exit_unlock:
++	spin_unlock_irqrestore(&hbus->retarget_msi_interrupt_lock, flags);
++
++	/*
++	 * During hibernation, when a CPU is offlined, the kernel tries
++	 * to move the interrupt to the remaining CPUs that haven't
++	 * been offlined yet. In this case, the below hv_do_hypercall()
++	 * always fails since the vmbus channel has been closed:
++	 * refer to cpu_disable_common() -> fixup_irqs() ->
++	 * irq_migrate_all_off_this_cpu() -> migrate_one_irq().
++	 *
++	 * Suppress the error message for hibernation because the failure
++	 * during hibernation does not matter (at this time all the devices
++	 * have been frozen). Note: the correct affinity info is still updated
++	 * into the irqdata data structure in migrate_one_irq() ->
++	 * irq_do_set_affinity() -> hv_set_affinity(), so later when the VM
++	 * resumes, hv_pci_restore_msi_state() is able to correctly restore
++	 * the interrupt with the correct affinity.
++	 */
++	if (!hv_result_success(res) && hbus->state != hv_pcibus_removing)
++		dev_err(&hbus->hdev->device,
++			"%s() failed: %#llx", __func__, res);
++}
+ #elif defined(CONFIG_ARM64)
+ /*
+  * SPI vectors to use for vPCI; arch SPIs range is [32, 1019], but leaving a bit
+@@ -841,6 +959,12 @@ static struct irq_domain *hv_pci_get_root_domain(void)
+ {
+ 	return hv_msi_gic_irq_domain;
+ }
++
++/*
++ * SPIs are used for interrupts of PCI devices and SPIs is managed via GICD
++ * registers which Hyper-V already supports, so no hypercall needed.
++ */
++static void hv_arch_irq_unmask(struct irq_data *data) { }
+ #endif /* CONFIG_ARM64 */
+ 
+ /**
+@@ -1462,122 +1586,9 @@ static void hv_irq_mask(struct irq_data *data)
+ 		irq_chip_mask_parent(data);
+ }
+ 
+-/**
+- * hv_irq_unmask() - "Unmask" the IRQ by setting its current
+- * affinity.
+- * @data:	Describes the IRQ
+- *
+- * Build new a destination for the MSI and make a hypercall to
+- * update the Interrupt Redirection Table. "Device Logical ID"
+- * is built out of this PCI bus's instance GUID and the function
+- * number of the device.
+- */
+ static void hv_irq_unmask(struct irq_data *data)
+ {
+-	struct msi_desc *msi_desc = irq_data_get_msi_desc(data);
+-	struct hv_retarget_device_interrupt *params;
+-	struct tran_int_desc *int_desc;
+-	struct hv_pcibus_device *hbus;
+-	struct cpumask *dest;
+-	cpumask_var_t tmp;
+-	struct pci_bus *pbus;
+-	struct pci_dev *pdev;
+-	unsigned long flags;
+-	u32 var_size = 0;
+-	int cpu, nr_bank;
+-	u64 res;
+-
+-	dest = irq_data_get_effective_affinity_mask(data);
+-	pdev = msi_desc_to_pci_dev(msi_desc);
+-	pbus = pdev->bus;
+-	hbus = container_of(pbus->sysdata, struct hv_pcibus_device, sysdata);
+-	int_desc = data->chip_data;
+-
+-	spin_lock_irqsave(&hbus->retarget_msi_interrupt_lock, flags);
+-
+-	params = &hbus->retarget_msi_interrupt_params;
+-	memset(params, 0, sizeof(*params));
+-	params->partition_id = HV_PARTITION_ID_SELF;
+-	params->int_entry.source = HV_INTERRUPT_SOURCE_MSI;
+-	params->int_entry.msi_entry.address.as_uint32 = int_desc->address & 0xffffffff;
+-	params->int_entry.msi_entry.data.as_uint32 = int_desc->data;
+-	params->device_id = (hbus->hdev->dev_instance.b[5] << 24) |
+-			   (hbus->hdev->dev_instance.b[4] << 16) |
+-			   (hbus->hdev->dev_instance.b[7] << 8) |
+-			   (hbus->hdev->dev_instance.b[6] & 0xf8) |
+-			   PCI_FUNC(pdev->devfn);
+-	params->int_target.vector = hv_msi_get_int_vector(data);
+-
+-	/*
+-	 * Honoring apic->delivery_mode set to APIC_DELIVERY_MODE_FIXED by
+-	 * setting the HV_DEVICE_INTERRUPT_TARGET_MULTICAST flag results in a
+-	 * spurious interrupt storm. Not doing so does not seem to have a
+-	 * negative effect (yet?).
+-	 */
+-
+-	if (hbus->protocol_version >= PCI_PROTOCOL_VERSION_1_2) {
+-		/*
+-		 * PCI_PROTOCOL_VERSION_1_2 supports the VP_SET version of the
+-		 * HVCALL_RETARGET_INTERRUPT hypercall, which also coincides
+-		 * with >64 VP support.
+-		 * ms_hyperv.hints & HV_X64_EX_PROCESSOR_MASKS_RECOMMENDED
+-		 * is not sufficient for this hypercall.
+-		 */
+-		params->int_target.flags |=
+-			HV_DEVICE_INTERRUPT_TARGET_PROCESSOR_SET;
+-
+-		if (!alloc_cpumask_var(&tmp, GFP_ATOMIC)) {
+-			res = 1;
+-			goto exit_unlock;
+-		}
+-
+-		cpumask_and(tmp, dest, cpu_online_mask);
+-		nr_bank = cpumask_to_vpset(&params->int_target.vp_set, tmp);
+-		free_cpumask_var(tmp);
+-
+-		if (nr_bank <= 0) {
+-			res = 1;
+-			goto exit_unlock;
+-		}
+-
+-		/*
+-		 * var-sized hypercall, var-size starts after vp_mask (thus
+-		 * vp_set.format does not count, but vp_set.valid_bank_mask
+-		 * does).
+-		 */
+-		var_size = 1 + nr_bank;
+-	} else {
+-		for_each_cpu_and(cpu, dest, cpu_online_mask) {
+-			params->int_target.vp_mask |=
+-				(1ULL << hv_cpu_number_to_vp_number(cpu));
+-		}
+-	}
+-
+-	res = hv_do_hypercall(HVCALL_RETARGET_INTERRUPT | (var_size << 17),
+-			      params, NULL);
+-
+-exit_unlock:
+-	spin_unlock_irqrestore(&hbus->retarget_msi_interrupt_lock, flags);
+-
+-	/*
+-	 * During hibernation, when a CPU is offlined, the kernel tries
+-	 * to move the interrupt to the remaining CPUs that haven't
+-	 * been offlined yet. In this case, the below hv_do_hypercall()
+-	 * always fails since the vmbus channel has been closed:
+-	 * refer to cpu_disable_common() -> fixup_irqs() ->
+-	 * irq_migrate_all_off_this_cpu() -> migrate_one_irq().
+-	 *
+-	 * Suppress the error message for hibernation because the failure
+-	 * during hibernation does not matter (at this time all the devices
+-	 * have been frozen). Note: the correct affinity info is still updated
+-	 * into the irqdata data structure in migrate_one_irq() ->
+-	 * irq_do_set_affinity() -> hv_set_affinity(), so later when the VM
+-	 * resumes, hv_pci_restore_msi_state() is able to correctly restore
+-	 * the interrupt with the correct affinity.
+-	 */
+-	if (!hv_result_success(res) && hbus->state != hv_pcibus_removing)
+-		dev_err(&hbus->hdev->device,
+-			"%s() failed: %#llx", __func__, res);
++	hv_arch_irq_unmask(data);
+ 
+ 	if (data->parent_data->chip->irq_unmask)
+ 		irq_chip_unmask_parent(data);
+-- 
+2.34.1
+

--- a/sys-kernel/coreos-sources/files/5.15/z0007-PCI-hv-Remove-unused-hv_set_msi_entry_from_desc.patch
+++ b/sys-kernel/coreos-sources/files/5.15/z0007-PCI-hv-Remove-unused-hv_set_msi_entry_from_desc.patch
@@ -1,0 +1,50 @@
+From d840bda57a70e672dcd2d5adbac5ef1f76c3082a Mon Sep 17 00:00:00 2001
+From: YueHaibing <yuehaibing@huawei.com>
+Date: Thu, 17 Mar 2022 16:51:30 +0800
+Subject: [PATCH 7/7] PCI: hv: Remove unused hv_set_msi_entry_from_desc()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix the following build error:
+
+  drivers/pci/controller/pci-hyperv.c:769:13: error: ‘hv_set_msi_entry_from_desc’ defined but not used [-Werror=unused-function]
+    769 | static void hv_set_msi_entry_from_desc(union hv_msi_entry *msi_entry,
+
+The arm64 implementation of hv_set_msi_entry_from_desc() is not used after
+d06957d7a692 ("PCI: hv: Avoid the retarget interrupt hypercall in
+irq_unmask() on ARM64"), so remove it.
+
+Fixes: d06957d7a692 ("PCI: hv: Avoid the retarget interrupt hypercall in irq_unmask() on ARM64")
+Link: https://lore.kernel.org/r/20220317085130.36388-1-yuehaibing@huawei.com
+Signed-off-by: YueHaibing <yuehaibing@huawei.com>
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Acked-by: Boqun Feng <boqun.feng@gmail.com>
+(cherry picked from commit 22ef7ee3eeb2a41e07f611754ab9a2663232fedf)
+---
+ drivers/pci/controller/pci-hyperv.c | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-hyperv.c b/drivers/pci/controller/pci-hyperv.c
+index 165dfb98d3d8..2db98b4fbc1f 100644
+--- a/drivers/pci/controller/pci-hyperv.c
++++ b/drivers/pci/controller/pci-hyperv.c
+@@ -771,14 +771,6 @@ static unsigned int hv_msi_get_int_vector(struct irq_data *irqd)
+ 	return irqd->parent_data->hwirq;
+ }
+ 
+-static void hv_set_msi_entry_from_desc(union hv_msi_entry *msi_entry,
+-				       struct msi_desc *msi_desc)
+-{
+-	msi_entry->address = ((u64)msi_desc->msg.address_hi << 32) |
+-			      msi_desc->msg.address_lo;
+-	msi_entry->data = msi_desc->msg.data;
+-}
+-
+ /*
+  * @nr_bm_irqs:		Indicates the number of IRQs that were allocated from
+  *			the bitmap.
+-- 
+2.34.1
+


### PR DESCRIPTION
The first hyperv patch needed a regeneration, while the last one could
be dropped as it was already backported to 5.15.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/80/cldsv/

CC: @jepio 