### PR TITLE
profiles: enable dev-vcs/git 2.37.1

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -59,8 +59,8 @@
 # FIPS support is still being tested
 =sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64
 
-# Required for CVE-2022-24765
-=dev-vcs/git-2.35.3 ~amd64 ~arm64
+# Required for CVE-2022-29187
+=dev-vcs/git-2.37.1 ~amd64 ~arm64
 
 =sys-power/acpid-2.0.33 ~amd64 ~arm64
 

--- a/profiles/coreos/base/package.unmask
+++ b/profiles/coreos/base/package.unmask
@@ -11,4 +11,4 @@
 
 # Overwrite portage-stable mask - we want to use this version of git
 # for security fixes.
-=dev-vcs/git-2.35.3
+=dev-vcs/git-2.37.1


### PR DESCRIPTION
To be able to address [CVE-2022-29187](https://nvd.nist.gov/vuln/detail/CVE-2022-29187), we need to accept keywords and unmask `dev-vcs/gi`t 2.37.1.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/347.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6285/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (done in https://github.com/flatcar-linux/portage-stable/pull/347)
