### PR TITLE
coreos-base/coreos-init: Add new image signing key to flatcar-install

### DIFF
--- a/changelog/changes/2022-08-11-new-image-signing-subkey.md
+++ b/changelog/changes/2022-08-11-new-image-signing-subkey.md
@@ -1,0 +1,1 @@
+- The new image signing subkey was added to the public key embedded into `flatcar-install` (the old expired on 10th August 2022), only an updated `flatcar-install` script can verify releases signed with the new key ([init#79](https://github.com/flatcar-linux/init/pull/79))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="2e0b31dc3aed008550489151143e761d4ebeead0" # flatcar-master
+	CROS_WORKON_COMMIT="0a77e274e05a4db82d18ad6d20d23b3cbdf31e2f" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar-linux/init/pull/79
to updated the embedded pub key in flatcar-install to include the new
subkey that is used for signing new releases.

## How to use

Backport together with backport branches in "init"


- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
