### PR TITLE
Flatcar support for EKS on versions above 1.21

### DIFF
--- a/changelog/bugfixes/2022-08-22-eks-support-for-versions-above-1.21.md
+++ b/changelog/bugfixes/2022-08-22-eks-support-for-versions-above-1.21.md
@@ -1,0 +1,1 @@
+- Added EKS support for version 1.22 and 1.23. Fixed `/usr/share/oem/eks/download-kubelet.sh` to include download paths for these versions. ([coreos-overlay#2110](https://github.com/flatcar-linux/coreos-overlay/pull/2110))

--- a/changelog/bugfixes/2022-08-22-eks-support-for-versions-above-1.21.md
+++ b/changelog/bugfixes/2022-08-22-eks-support-for-versions-above-1.21.md
@@ -1,1 +1,1 @@
-- Added EKS support for version 1.22 and 1.23. Fixed `/usr/share/oem/eks/download-kubelet.sh` to include download paths for these versions. ([coreos-overlay#2110](https://github.com/flatcar-linux/coreos-overlay/pull/2110))
+- AWS: added EKS support for version 1.22 and 1.23. ([coreos-overlay#2110](https://github.com/flatcar-linux/coreos-overlay/pull/2110), [Flatcar#829](https://github.com/flatcar-linux/Flatcar/issues/829))

--- a/coreos-base/flatcar-eks/files/download-kubelet.sh
+++ b/coreos-base/flatcar-eks/files/download-kubelet.sh
@@ -23,10 +23,10 @@ fi
 # https://github.com/awslabs/amazon-eks-ami/blob/master/Makefile
 case $CLUSTER_VERSION in
   1.23)
-    S3_PATH="1.23.9/2022-07-27/"
+    S3_PATH="1.23.9/2022-07-27"
     ;;
   1.22)
-    S3_PATH="1.22.12/2022-07-27/"
+    S3_PATH="1.22.12/2022-07-27"
     ;;
   1.21)
     S3_PATH="1.21.2/2021-07-05"

--- a/coreos-base/flatcar-eks/files/download-kubelet.sh
+++ b/coreos-base/flatcar-eks/files/download-kubelet.sh
@@ -22,6 +22,12 @@ fi
 # Select the right path depending on the Kubernetes version.
 # https://github.com/awslabs/amazon-eks-ami/blob/master/Makefile
 case $CLUSTER_VERSION in
+  1.23)
+    S3_PATH="1.23.9/2022-07-27/"
+    ;;
+  1.22)
+    S3_PATH="1.22.12/2022-07-27/"
+    ;;
   1.21)
     S3_PATH="1.21.2/2021-07-05"
     ;;


### PR DESCRIPTION
## Description

When an EC2 instance boots up with a flatcar image (even the latest) the kubelet fails.
The userdata defines (and should do so) that the `/etc/eks/bootstrap.sh` should run, which it does.

This seems to add a ExecStartPre to the kubelet.service:
`ExecStartPre=/usr/share/oem/eks/download-kubelet.sh`

Both the `bootstrap.sh` and the `download-kubelet.sh` are consistent with:
https://github.com/flatcar-linux/coreos-overlay/blob/main/coreos-base/flatcar-eks/files/bootstrap.sh
https://github.com/flatcar-linux/coreos-overlay/blob/main/coreos-base/flatcar-eks/files/download-kubelet.sh

The `download-kubelet.sh` fails with `Unsupported Kubernetes version` because in the case statement on line 24->50 (https://github.com/flatcar-linux/coreos-overlay/blob/main/coreos-base/flatcar-eks/files/download-kubelet.sh#L25) only has values for kubernetes version 1.15 -> 1.21

If I manually alter the file and add 1.22 (when I test this on 1.22.9 kubernetes version deployment) and re-run the `bootsrap.sh` it works fine as far as I can see, the node than joins the cluster and shows up as `Ready` and pods starting running on the node.

The last PR I can see on this particular thing was done about a year ago https://github.com/flatcar-linux/coreos-overlay/commit/f0da7f8c9e787178257eef31c87f874a9107fbf2

## Impact

No EKS support for kubernetes versions higher than 1.21

## Environment and steps to reproduce

1. **Set-up**: Create an EKS cluster with the latest flatcar AMI in the worker nodes
2. **Task**: SSH into the node (probably through a Bastion)
3. **Action(s)**:  No actions needed
4. **Error**: kubelet.service fails because the download-kubelet.sh doesn't have download locations for kubernetes version above 1.21

## Expected behavior

Download locations for kubernetes versions 1.22 and 1.23 (EKS doesn't have support for 1.24 yet it seems) should be located inside the download-kubelet.sh

## Additional information

By running `aws s3 ls s3://amazon-eks/` you can list the available locations of the other versions, so for it should result in this:

``` sh
case $CLUSTER_VERSION in
  1.23)
    S3_PATH="1.23.9/2022-07-27"
    ;;
  1.22)
    S3_PATH="1.22.12/2022-07-27"
    ;;
  1.21)
    S3_PATH="1.21.2/2021-07-05"
    ;;
  1.20)
    S3_PATH="1.20.4/2021-04-12"
    ;;
  1.19)
    S3_PATH="1.19.6/2021-01-05"
    ;;
  1.18)
    S3_PATH="1.18.9/2020-11-02"
    ;;
  1.17)
    S3_PATH="1.17.12/2020-11-02"
    ;;
  1.16)
    S3_PATH="1.16.15/2020-11-02"
    ;;
  1.15)
    S3_PATH="1.15.12/2020-11-02"
    ;;
  *)
    echo "Unsupported Kubernetes version"
    exit 1
    ;;
esac
```

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

Closes: https://github.com/flatcar-linux/Flatcar/issues/829

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
