### PR TITLE
coreos-base/coreos-init: sync commit ID

### DIFF
--- a/changelog/bugfixes/2022-08-29-vmware-wireguard.md
+++ b/changelog/bugfixes/2022-08-29-vmware-wireguard.md
@@ -1,0 +1,1 @@
+- VMWare: excluded `wireguard` (and others) from `systemd-networkd` management. ([init#80](https://github.com/flatcar-linux/init/pull/80))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="0a77e274e05a4db82d18ad6d20d23b3cbdf31e2f" # flatcar-master
+	CROS_WORKON_COMMIT="ffa29e69243a5752b44e03642634b67261275b67" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
this pulls the wireguard exclusion from systemd-networkd management on VMWare to sync configuration file with `zz-default`. 

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6380/cldsv/

<hr>

Related PRs:
- https://github.com/flatcar-linux/mantle/pull/361
- https://github.com/flatcar-linux/init/pull/80
- https://github.com/flatcar-linux/Flatcar/issues/808