### PR TITLE
coreos-base/oem-packet: Use i386 serial settings for x86_64 to fix m3

### DIFF
--- a/changelog/bugfixes/2022-08-30-equinix-metal-serial.md
+++ b/changelog/bugfixes/2022-08-30-equinix-metal-serial.md
@@ -1,0 +1,1 @@
+- Equinix Metal: Fixed serial console settings for the `m3.small.x86` instance by expanding the GRUB check for `i386` to `x86_64` [coreos-overlay#2122](https://github.com/flatcar-linux/coreos-overlay/pull/2122)

--- a/coreos-base/oem-packet/files/grub.cfg
+++ b/coreos-base/oem-packet/files/grub.cfg
@@ -3,7 +3,7 @@
 set oem_id="packet"
 set linux_append="flatcar.autologin"
 
-if [ "$grub_cpu" = i386 ]; then
+if [ "$grub_cpu" = i386 ] || [ "$grub_cpu" = x86_64 ]; then
     set gfxpayload="1024x768x8,1024x768"
     set linux_console="console=tty0 console=ttyS1,115200n8"
 fi


### PR DESCRIPTION
The m3.small.x86 instance type had no serial console output because
ttyS0 was used because the GRUB CPU check didn't trigger. It seems that
most instances had i386 reported but this new one not (maybe EFI is
used here?).
Extend the GRUB check to cover both i386 and x86_64 when setting up the
serial console. For arm64 this still shouldn't be needed and the
defaults worked so far.

## How to use

Test again on other instance types that the serial console works as expected.

Backport

## Testing done

On m3.small, c3.medium, s3.xlarge

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
