### PR TITLE
.github: migrate to SDK container based Github Actions

### DIFF
--- a/.github/workflows/cacerts-apply-patch.sh
+++ b/.github/workflows/cacerts-apply-patch.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 UPDATE_NEEDED=1
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
 
 . .github/workflows/common.sh
 
 prepare_git_repo
 
-if ! checkout_branches "${VERSION_NEW}-${TARGET}"; then
+if ! checkout_branches "${VERSION_NEW}-${TARGET}" "${CHECKOUT_SCRIPTS}"; then
   UPDATE_NEEDED=0
   exit 0
 fi

--- a/.github/workflows/cacerts-releases-alpha.yml
+++ b/.github/workflows/cacerts-releases-alpha.yml
@@ -32,6 +32,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/cacerts-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/cacerts-releases-beta.yml
+++ b/.github/workflows/cacerts-releases-beta.yml
@@ -32,6 +32,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/cacerts-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/cacerts-releases-lts-2021.yml
+++ b/.github/workflows/cacerts-releases-lts-2021.yml
@@ -30,6 +30,9 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          CHECKOUT_SCRIPTS: "false"
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/cacerts-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/cacerts-releases-lts.yml
+++ b/.github/workflows/cacerts-releases-lts.yml
@@ -32,6 +32,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/cacerts-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/cacerts-releases-main.yaml
+++ b/.github/workflows/cacerts-releases-main.yaml
@@ -29,6 +29,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/cacerts-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/cacerts-releases-stable.yml
+++ b/.github/workflows/cacerts-releases-stable.yml
@@ -32,6 +32,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/cacerts-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 UPDATE_NEEDED=1
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
 
 . .github/workflows/common.sh
 
 prepare_git_repo
 
-if ! checkout_branches "containerd-${VERSION_NEW}-${TARGET}"; then
+if ! checkout_branches "${VERSION_NEW}-${TARGET}" "${CHECKOUT_SCRIPTS}"; then
   UPDATE_NEEDED=0
   exit 0
 fi

--- a/.github/workflows/containerd-releases-main.yml
+++ b/.github/workflows/containerd-releases-main.yml
@@ -32,6 +32,8 @@ jobs:
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
           COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_MAIN }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/containerd-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 UPDATE_NEEDED=1
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
 
 . .github/workflows/common.sh
 
 prepare_git_repo
 
-if ! checkout_branches "docker-${VERSION_NEW}-${TARGET}"; then
+if ! checkout_branches "docker-${VERSION_NEW}-${TARGET}" "${CHECKOUT_SCRIPTS}"; then
   UPDATE_NEEDED=0
   exit 0
 fi

--- a/.github/workflows/docker-releases-main.yml
+++ b/.github/workflows/docker-releases-main.yml
@@ -36,6 +36,8 @@ jobs:
           COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_MAIN }}
           COMMIT_CLI_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_CLI }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/docker-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/firmware-apply-patch.sh
+++ b/.github/workflows/firmware-apply-patch.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 UPDATE_NEEDED=1
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
 
 . .github/workflows/common.sh
 
 prepare_git_repo
 
-if ! checkout_branches "${VERSION_NEW}-${TARGET}"; then
+if ! checkout_branches "${VERSION_NEW}-${TARGET}" "${CHECKOUT_SCRIPTS}"; then
   UPDATE_NEEDED=0
   exit 0
 fi

--- a/.github/workflows/firmware-releases-main.yml
+++ b/.github/workflows/firmware-releases-main.yml
@@ -29,6 +29,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/firmware-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -19,13 +19,15 @@ for version_new in ${VERSIONS_NEW}; do
   VERSIONS["${version_new_trimmed}"]="${version_new}"
 done
 
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
+
 . .github/workflows/common.sh
 
 prepare_git_repo
 
 branch_name="go-$(join_by '-and-' ${VERSIONS_NEW})-${TARGET}"
 
-if ! checkout_branches "${branch_name}"; then
+if ! checkout_branches "${branch_name}" "${CHECKOUT_SCRIPTS}"; then
   exit 0
 fi
 

--- a/.github/workflows/go-releases-main.yml
+++ b/.github/workflows/go-releases-main.yml
@@ -34,6 +34,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-releases.outputs.BASE_BRANCH_MAIN }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSIONS_NEW: ${{ steps.fetch-latest-releases.outputs.VERSIONS_MAIN }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/go-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -5,12 +5,13 @@ set -euo pipefail
 # trim the 3rd part in the input semver, e.g. from 5.4.1 to 5.4
 VERSION_SHORT=${VERSION_NEW%.*}
 UPDATE_NEEDED=1
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
 
 . .github/workflows/common.sh
 
 prepare_git_repo
 
-if ! checkout_branches "linux-${VERSION_NEW}-${TARGET}"; then
+if ! checkout_branches "linux-${VERSION_NEW}-${TARGET}" "${CHECKOUT_SCRIPTS}"; then
   UPDATE_NEEDED=0
   exit 0
 fi

--- a/.github/workflows/kernel-releases-alpha.yml
+++ b/.github/workflows/kernel-releases-alpha.yml
@@ -33,6 +33,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/kernel-releases-beta.yml
+++ b/.github/workflows/kernel-releases-beta.yml
@@ -33,6 +33,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/kernel-releases-lts-2021.yml
+++ b/.github/workflows/kernel-releases-lts-2021.yml
@@ -33,6 +33,9 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          CHECKOUT_SCRIPTS: "false"
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/kernel-releases-lts.yml
+++ b/.github/workflows/kernel-releases-lts.yml
@@ -33,6 +33,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/kernel-releases-main.yml
+++ b/.github/workflows/kernel-releases-main.yml
@@ -31,6 +31,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/kernel-releases-stable.yml
+++ b/.github/workflows/kernel-releases-stable.yml
@@ -33,6 +33,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAINTENANCE }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAINTENANCE }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/kernel-apply-patch.sh
       - name: Create pull request for maintenance branch
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 UPDATE_NEEDED=1
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
 
 . .github/workflows/common.sh
 
 prepare_git_repo
 
-if ! checkout_branches "runc-${VERSION_NEW}-${TARGET}"; then
+if ! checkout_branches "runc-${VERSION_NEW}-${TARGET}" "${CHECKOUT_SCRIPTS}"; then
   UPDATE_NEEDED=0
   exit 0
 fi

--- a/.github/workflows/runc-releases-main.yml
+++ b/.github/workflows/runc-releases-main.yml
@@ -36,6 +36,8 @@ jobs:
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
           COMMIT_HASH: ${{ steps.fetch-latest-release.outputs.COMMIT_MAIN }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/runc-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 UPDATE_NEEDED=1
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
 
 . .github/workflows/common.sh
 
 prepare_git_repo
 
-if ! checkout_branches "rust-${VERSION_NEW}-${TARGET}"; then
+if ! checkout_branches "rust-${VERSION_NEW}-${TARGET}" "${CHECKOUT_SCRIPTS}"; then
   UPDATE_NEEDED=0
   exit 0
 fi

--- a/.github/workflows/rust-release-main.yml
+++ b/.github/workflows/rust-release-main.yml
@@ -29,6 +29,8 @@ jobs:
           BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/rust-apply-patch.sh
       - name: Create pull request for main
         id: create-pull-request

--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -2,62 +2,51 @@
 
 set -euo pipefail
 
-sudo apt-get install -y lbzip2
+sudo ln -sfn /bin/bash /bin/sh
+sudo apt-get install -y ca-certificates curl git gnupg lbzip2 lsb-release \
+    qemu-user-static
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+    https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io \
+    docker-compose-plugin
 
-CORK_VERSION=$(curl -sL https://api.github.com/repos/kinvolk/mantle/releases/latest | jq -r .tag_name | sed -e 's/^v//')
-curl -L -o cork https://github.com/kinvolk/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64
-curl -L -o cork.sig https://github.com/kinvolk/mantle/releases/download/v"${CORK_VERSION}"/cork-"${CORK_VERSION}"-amd64.sig
-curl -LO https://kinvolk.io/flatcar-container-linux/security/image-signing-key/Flatcar_Image_Signing_Key.asc
-gpg --import Flatcar_Image_Signing_Key.asc
-gpg --verify cork.sig cork
-rm -f cork.sig Flatcar_Image_Signing_Key.asc
-chmod +x cork
-mkdir -p ~/.local/bin
-mv cork ~/.local/bin
-
-export PATH=$PATH:$HOME/.local/bin
 mkdir -p ~/flatcar-sdk
+git -C ~/flatcar-sdk clone https://github.com/flatcar-linux/scripts
 
-pushd ~/flatcar-sdk || exit
-cork create || true
+pushd ~/flatcar-sdk/scripts || exit
 
-sudo tee "./chroot/etc/portage/make.conf" <<EOF
-PORTDIR="/mnt/host/source/src/third_party/portage-stable"
-PORTDIR_OVERLAY="/mnt/host/source/src/third_party/coreos-overlay"
-DISTDIR="/mnt/host/source/.cache/distfiles"
-PKGDIR="/var/lib/portage/pkgs"
-PORT_LOGDIR="/var/log/portage"
-EOF
+source ci-automation/ci_automation_common.sh
+source sdk_container/.repo/manifests/version.txt
 
-sudo tee "./chroot/etc/portage/repos.conf/coreos.conf" <<EOF
-[DEFAULT]
-main-repo = portage-stable
+git submodule update --init --recursive
 
-[gentoo]
-disabled = true
+arch="amd64"
+channel_version="alpha-${FLATCAR_VERSION_ID}"
+check_version_string "${channel_version}"
 
-[coreos]
-location = /mnt/host/source/src/third_party/coreos-overlay
+export SDK_NAME="flatcar-sdk-${arch}"
 
-[portage-stable]
-location = /mnt/host/source/src/third_party/portage-stable
-EOF
+# Pin the docker image version to that of the latest release.
+docker_sdk_vernum="$(curl -s -S -f -L \
+    https://alpha.release.flatcar-linux.net/amd64-usr/current/version.txt \
+    | grep -m 1 FLATCAR_SDK_VERSION= | cut -d = -f 2- \
+)"
 
-# /var under the chroot has to be writable by the runner user
-sudo chown -R runner:docker ~/flatcar-sdk/chroot/var
+docker_image_from_registry_or_buildcache "${SDK_NAME}" "${docker_sdk_vernum}"
+export SDK_NAME="$(docker_image_fullname "${SDK_NAME}" "${docker_sdk_vernum}")"
 
-function enter() ( exec cork enter -- $@ )
+vernum="${channel_version#*-}" # remove main-,alpha-,beta-,stable-,lts- version tag
+docker_vernum="$(vernum_to_docker_image_version "${vernum}")"
+export PACKAGES_CONTAINER="flatcar-packages-${arch}-${docker_vernum}"
 
-# To be able to generate metadata, we need to configure a profile
-# /etc/portage/make.profile, a symlink pointing to the SDK profile.
-enter sudo eselect profile set --force "coreos:coreos/amd64/sdk"
-
-# make edb directory group-writable to run egencache
-enter sudo chmod g+w /var/cache/edb
-
-git -C src/third_party/coreos-overlay reset --hard github/main
-git -C src/third_party/coreos-overlay config user.name 'Flatcar Buildbot'
-git -C src/third_party/coreos-overlay config user.email 'buildbot@flatcar-linux.org'
 popd || exit
 
 echo ::set-output name=path::"${PATH}"
+echo ::set-output name=PACKAGES_CONTAINER::"${PACKAGES_CONTAINER}"
+echo ::set-output name=SDK_NAME::"${SDK_NAME}"

--- a/.github/workflows/vmware-apply-patch.sh
+++ b/.github/workflows/vmware-apply-patch.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 UPDATE_NEEDED=1
+CHECKOUT_SCRIPTS="${CHECKOUT_SCRIPTS:-true}"
 
 . .github/workflows/common.sh
 
 prepare_git_repo
 
-if ! checkout_branches "${VERSION_NEW}-${TARGET}"; then
+if ! checkout_branches "${VERSION_NEW}-${TARGET}" "${CHECKOUT_SCRIPTS}"; then
   UPDATE_NEEDED=0
   exit 0
 fi

--- a/.github/workflows/vmware-releases-main.yml
+++ b/.github/workflows/vmware-releases-main.yml
@@ -32,6 +32,8 @@ jobs:
           BUILD_NUMBER: ${{ steps.fetch-latest-release.outputs.BUILD_NUMBER }}
           PATH: ${{ steps.setup-flatcar-sdk.outputs.path }}
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
+          SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/vmware-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Now that Flatcar SDK does not support cork of mantle any more, we need to migrate the Github Actions of coreos-overlay to the new container SDK based approach.

Simply download a container image of the latest Flatcar release, run the container, generate patches from there.

Note, since the Flatcar scripts repo of LTS-2021 still does not have necessary Container SDK scripts like run_sdk_container, we need to skip checking out a specific base branch in case of LTS-2021.

Fixes https://github.com/flatcar-linux/Flatcar/issues/844

## Testing done

tested almost all

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
