### PR TITLE
profiles: accept keywords and clean up for rsync 3.2.6

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -19,8 +19,8 @@
 
 =net-misc/openssh-8.8_p1-r3 ~amd64 ~arm64
 
-# Required for addressing CVE-2018-25032 in its bundled zlib
-=net-misc/rsync-3.2.4-r1 ~amd64 ~arm64
+# Required for addressing CVE-2022-29154
+=net-misc/rsync-3.2.6 ~amd64 ~arm64
 
 # To address security issues like CVE-2021-31879, we need to accept
 # keywords for wget 1.21.2.

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -100,9 +100,6 @@ app-emulation/docker-runc selinux
 # enable regular expression processing in jq
 app-misc/jq oniguruma
 
-# Disable sse2 from CPU_FLAGS_X86 to avoid config error around simd
-net-misc/rsync -cpu_flags_x86_sse2
-
 # Don't read the firmware config from /etc/portage/savedconfig/
 sys-kernel/coreos-firmware -savedconfig
 


### PR DESCRIPTION
To address [CVE-2022-29154](https://nvd.nist.gov/vuln/detail/CVE-2022-29154), we need to accept keywords `~amd64` and `~arm64` for rsync 3.2.6.

Since rsync 3.2.4, IUSE_CPU_FLAGS_X86="sse2" does not exist any more in upstream ebuilds.
So it is not necessary to disable `cpu_flags_x86_sse2` USE flag for avoiding cross toolchain build failures.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/356.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/304/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
