### PR TITLE
coreos-base/coreos: add sys-devel/gettext

### DIFF
--- a/changelog/bugfixes/2022-09-13-gettext.md
+++ b/changelog/bugfixes/2022-09-13-gettext.md
@@ -1,0 +1,1 @@
+- Added back `gettext` to the OS ([Flatcar#849](https://github.com/flatcar-linux/Flatcar/issues/849))

--- a/changelog/updates/2022-09-13-gettext.md
+++ b/changelog/updates/2022-09-13-gettext.md
@@ -1,0 +1,1 @@
+- gettext ([0.21](https://www.gnu.org/software/gettext/))

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -78,6 +78,7 @@ RDEPEND="${RDEPEND}
 		app-emulation/xenstore
 	)"
 
+# sys-devel/gettext: it embeds 'envsubst' binary which is useful for simple file templating.
 RDEPEND="${RDEPEND}
 	app-admin/etcd-wrapper
 	app-admin/flannel-wrapper
@@ -175,6 +176,7 @@ RDEPEND="${RDEPEND}
 	sys-block/parted
 	sys-boot/efibootmgr
 	sys-cluster/ipvsadm
+	sys-devel/gettext
 	sys-fs/btrfs-progs
 	sys-fs/cryptsetup
 	sys-fs/dosfstools


### PR DESCRIPTION
This Flatcar dependency needs to be now explicitly pulled in the OS since this commit: https://github.com/flatcar-linux/coreos-overlay/pull/1724/commits/4a06200e9d92dc8066425cfc18dd6b7c5aa99131

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
```
14:05:51  +/usr/bin/envsubst
...
14:05:51  +/usr/bin/gettext
14:05:51  +/usr/bin/gettext.sh
14:05:51  +/usr/bin/gettextize
```
- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6491/cldsv/ (except for dev-container but seems unrelated)

Closes: https://github.com/flatcar-linux/Flatcar/issues/849