### PR TITLE
.github: run apt-get update before installing native Ubuntu packages

### DIFF
--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 sudo ln -sfn /bin/bash /bin/sh
+sudo apt-get update
 sudo apt-get install -y ca-certificates curl git gnupg lbzip2 lsb-release \
     qemu-user-static
 sudo mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
We should run apt-get update before installing native Ubuntu packages like qemu-user-static. Otherwise apt-get install could fail like:

```
Err:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe
amd64 qemu-user-static amd64 1:6.2+dfsg-2ubuntu6.5
  404  Not Found [IP: 52.252.75.106 80]
```

That happens because meanwhile the `qemu-user-static` deb package in the Azure mirror was updated from 6.5 to 6.6, without keeping the old version. Its index of the Azure mirror was updated, but `setup-flatcra-sdk.sh` did not sync that, as apt-get update did not run.

## Testing done

Tested via my fork.
