### PR TITLE
profiles: Drop accept keywords for app-arch/zstd

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -2,8 +2,6 @@
 # Copyright (c) 2013 The CoreOS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 
-=app-arch/zstd-1.4.9 ~amd64 ~arm64
-
 # Necessary to fix CVE-2023-0288 and CVE-2023-0433.
 =app-editors/vim-9.0.1363 ~amd64 ~arm64
 =app-editors/vim-core-9.0.1363 ~amd64 ~arm64


### PR DESCRIPTION
The updated packages is now stable for both amd64 and arm64.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/723/cldsv

Should be merged together with https://github.com/flatcar/portage-stable/pull/431