### PR TITLE
Update k8s binaries s3 paths

### DIFF
--- a/changelog/changes/2023-05-29-k8s-s3-paths.md
+++ b/changelog/changes/2023-05-29-k8s-s3-paths.md
@@ -1,0 +1,1 @@
+- Updated k8s binaries s3 paths to new ones including 1.22,1.23,1.24,1.25,1.26,1.27

--- a/coreos-base/flatcar-eks/files/download-kubelet.sh
+++ b/coreos-base/flatcar-eks/files/download-kubelet.sh
@@ -22,11 +22,20 @@ fi
 # Select the right path depending on the Kubernetes version.
 # https://github.com/awslabs/amazon-eks-ami/blob/master/Makefile
 case $CLUSTER_VERSION in
+  1.26)
+    S3_PATH="1.26.4/2023-05-11"
+    ;;
+  1.25)
+    S3_PATH="1.25.9/2023-05-11"
+    ;;
+  1.24)
+    S3_PATH="1.24.13/2023-05-11"
+    ;;
   1.23)
-    S3_PATH="1.23.9/2022-07-27"
+    S3_PATH="1.23.17/2023-05-11"
     ;;
   1.22)
-    S3_PATH="1.22.12/2022-07-27"
+    S3_PATH="1.22.17/2023-05-11"
     ;;
   1.21)
     S3_PATH="1.21.2/2021-07-05"


### PR DESCRIPTION
# Update k8s binaries s3 paths

Updated k8s binaries s3 paths to new ones

## How to use
Pass different cluster version

## Testing done

Verified the paths and their contents. Didn't try to create nodes and connect them to an EKS cluster (should I?)

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
